### PR TITLE
Throw an exception if inclusion fails

### DIFF
--- a/lib/Environment.php
+++ b/lib/Environment.php
@@ -91,6 +91,11 @@ class Environment
         }
     }
 
+    public function getConfiguration() : Configuration
+    {
+        return $this->configuration;
+    }
+
     public function getErrorManager() : ErrorManager
     {
         return $this->errorManager;

--- a/tests/ConfigurationTest.php
+++ b/tests/ConfigurationTest.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\RST;
+
+use Doctrine\RST\Configuration;
+use PHPUnit\Framework\TestCase;
+
+class ConfigurationTest extends TestCase
+{
+    /** @var Configuration */
+    private $configuration;
+
+    public function testUseRelativeUrls() : void
+    {
+        self::assertTrue($this->configuration->useRelativeUrls());
+
+        $this->configuration->setUseRelativeUrls(false);
+
+        self::assertFalse($this->configuration->useRelativeUrls());
+    }
+
+    public function testAbortOnError() : void
+    {
+        self::assertTrue($this->configuration->isAbortOnError());
+
+        $this->configuration->abortOnError(false);
+
+        self::assertFalse($this->configuration->isAbortOnError());
+    }
+
+    protected function setUp() : void
+    {
+        $this->configuration = new Configuration();
+    }
+}

--- a/tests/FileIncluderTest.php
+++ b/tests/FileIncluderTest.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\RST;
+
+use Doctrine\RST\Environment;
+use Doctrine\RST\FileIncluder;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+use function trim;
+
+class FileIncluderTest extends TestCase
+{
+    /** @var Environment|MockObject */
+    private $environment;
+
+    public function testInclude() : void
+    {
+        $this->environment->expects(self::once())
+            ->method('absoluteRelativePath')
+            ->with('include.rst')
+            ->willReturn(__DIR__ . '/files/include.rst');
+
+        $fileIncluder = new FileIncluder($this->environment, true, __DIR__ . '/files');
+
+        $contents = $fileIncluder->includeFiles('.. include:: include.rst');
+
+        self::assertSame('I was actually included', trim($contents));
+    }
+
+    public function testIncludeWithEmptyIncludeRoot() : void
+    {
+        $this->environment->expects(self::once())
+            ->method('absoluteRelativePath')
+            ->with('include.rst')
+            ->willReturn(__DIR__ . '/files/include.rst');
+
+        $fileIncluder = new FileIncluder($this->environment, true, '');
+
+        $contents = $fileIncluder->includeFiles('.. include:: include.rst');
+
+        self::assertSame('I was actually included', trim($contents));
+    }
+
+    public function testShouldThrowExceptionOnInvalidFileInclude() : void
+    {
+        $this->environment->expects(self::once())
+            ->method('absoluteRelativePath')
+            ->with('non-existent-file.rst')
+            ->willReturn('non-existent-file.rst');
+
+        $fileIncluder = new FileIncluder($this->environment, true, '');
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Include ".. include:: non-existent-file.rst" does not exist or is not readable.');
+
+        $fileIncluder->includeFiles('.. include:: non-existent-file.rst');
+    }
+
+    protected function setUp() : void
+    {
+        $this->environment = $this->createMock(Environment::class);
+    }
+}

--- a/tests/files/inclusion-bad.rst
+++ b/tests/files/inclusion-bad.rst
@@ -1,0 +1,4 @@
+Inclusion test
+==============
+
+.. include:: non-existent-file.rst


### PR DESCRIPTION
```rst
.. include:: non-existent-file.rst
```

Current behavior: the file inclusion is silently skipped
New behavior: an exception is thrown