### PR TITLE
fix toc tree glob

### DIFF
--- a/lib/Directives/Toctree.php
+++ b/lib/Directives/Toctree.php
@@ -91,7 +91,7 @@ class Toctree extends Directive
 
         $rootDocPath = rtrim(str_replace($environment->getDirName(), '', $currentFilePath), '/');
 
-        $globPatternPath = $rootDocPath . '/' . $globPattern;
+        $globPatternPath = $currentFilePath . '/' . $globPattern;
 
         $allFiles = [];
 

--- a/tests/BuilderTocTreeGlobTest.php
+++ b/tests/BuilderTocTreeGlobTest.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\RST;
+
+use Doctrine\RST\Builder;
+use PHPUnit\Framework\TestCase;
+use function file_exists;
+use function shell_exec;
+
+/**
+ * Unit testing for toc tree with :glob: option
+ */
+class BuilderTocTreeGlobTest extends TestCase
+{
+    public function setUp() : void
+    {
+        shell_exec('rm -rf ' . $this->targetFile());
+        $builder = new Builder();
+        $builder->setUseRelativeUrls(true);
+        $builder->build($this->sourceFile(), $this->targetFile(), false);
+    }
+
+    public function testTocTreeGlob() : void
+    {
+        self::assertTrue(file_exists($this->targetFile('subdir/toctree.html')));
+        self::assertFalse(file_exists($this->targetFile('not-parsed/file.html')));
+    }
+
+    private function sourceFile(string $file = '') : string
+    {
+        return __DIR__ . '/builder-toctree-glob/input/' . $file;
+    }
+
+    private function targetFile(string $file = '') : string
+    {
+        return __DIR__ . '/builder-toctree-glob/output/' . $file;
+    }
+}

--- a/tests/builder-toctree-glob/input/index.rst
+++ b/tests/builder-toctree-glob/input/index.rst
@@ -1,0 +1,6 @@
+Title
+=====
+
+.. toctree::
+
+    subdir/toctree

--- a/tests/builder-toctree-glob/input/not-parsed/file.rst
+++ b/tests/builder-toctree-glob/input/not-parsed/file.rst
@@ -1,0 +1,3 @@
+This file should not be parsed
+==============================
+

--- a/tests/builder-toctree-glob/input/subdir/toctree.rst
+++ b/tests/builder-toctree-glob/input/subdir/toctree.rst
@@ -1,0 +1,8 @@
+Toctree
+=======
+
+.. toctree::
+    :glob:
+
+    *
+

--- a/tests/builder-toctree-glob/output/index.html
+++ b/tests/builder-toctree-glob/output/index.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8" />
+</head>
+<body>
+<a id="title"></a><h1>Title</h1>
+<div class="toc"><ul><li id="subdir-toctree-html-toctree" class="toc-item"><a href="subdir/toctree.html#toctree">Toctree</a></li></ul></div>
+</body>
+</html>

--- a/tests/builder-toctree-glob/output/subdir/toctree.html
+++ b/tests/builder-toctree-glob/output/subdir/toctree.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8" />
+</head>
+<body>
+<a id="toctree"></a><h1>Toctree</h1>
+<div class="toc"><ul><li id="toctree-html-toctree" class="toc-item"><a href="toctree.html#toctree">Toctree</a></li></ul></div>
+</body>
+</html>


### PR DESCRIPTION
Hi,

this PR fixes a bug where using `.. toctree::` with `:glob:` option would actually parse all files present inside the root parsed path.

thanks.