### PR TITLE
Refactor toctree glob code

### DIFF
--- a/lib/GlobSearcher.php
+++ b/lib/GlobSearcher.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\RST;
+
+use Symfony\Component\Finder\Finder;
+use function array_merge;
+use function realpath;
+use function rtrim;
+use function str_replace;
+
+class GlobSearcher
+{
+    /**
+     * @return string[]
+     */
+    public function globSearch(Environment $environment, string $globPattern) : array
+    {
+        $currentFilePath = (string) realpath(rtrim($environment->absoluteRelativePath(''), '/'));
+
+        $rootDocPath = rtrim(str_replace($environment->getDirName(), '', $currentFilePath), '/');
+
+        if ($globPattern[0] === '/') {
+            $globPatternPath = $rootDocPath . $globPattern;
+        } else {
+            $globPatternPath = $currentFilePath . '/' . $globPattern;
+        }
+
+        $allFiles = [];
+
+        $finder = new Finder();
+        $finder->in(rtrim($globPatternPath, '*'))
+            ->name('*.rst')
+            ->files();
+
+        foreach ($finder as $file) {
+            if ($file->isDir()) {
+                // remove the root directory so it is a relative path from the root
+                $relativePath = str_replace($rootDocPath, '', (string) $file->getRealPath());
+
+                // recursively search in this directory
+                $dirFiles = $this->globSearch($environment, $relativePath . '/*');
+
+                $allFiles = array_merge($allFiles, $dirFiles);
+            } else {
+                // Trim the root path and the .rst extension. This is what the
+                // RST parser requires to add a dependency.
+                $file = str_replace([$rootDocPath, '.rst'], '', (string) $file->getRealPath());
+
+                $allFiles[] = $file;
+            }
+        }
+
+        return $allFiles;
+    }
+}

--- a/lib/ToctreeBuilder.php
+++ b/lib/ToctreeBuilder.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\RST;
+
+use Doctrine\RST\Nodes\Node;
+use function array_filter;
+use function array_map;
+use function explode;
+use function in_array;
+use function strpos;
+
+class ToctreeBuilder
+{
+    /** @var GlobSearcher */
+    private $globSearcher;
+
+    public function __construct(GlobSearcher $globSearcher)
+    {
+        $this->globSearcher = $globSearcher;
+    }
+
+    /**
+     * @param mixed[] $options
+     *
+     * @return string[]
+     */
+    public function buildToctreeFiles(
+        Environment $environment,
+        Node $node,
+        array $options
+    ) : array {
+        $toctreeFiles = [];
+
+        foreach ($this->parseToctreeFiles($node) as $file) {
+            if ($this->isGlob($options, $file)) {
+                $globPattern = $file;
+
+                $globFiles = $this->globSearcher
+                    ->globSearch($environment, $globPattern);
+
+                foreach ($globFiles as $globFile) {
+                    // if glob finds a file already explicitly defined
+                    // don't duplicate it in the toctree again
+                    if (in_array($globFile, $toctreeFiles, true)) {
+                        continue;
+                    }
+
+                    $toctreeFiles[] = $globFile;
+                }
+            } else {
+                $absoluteUrl = $environment->absoluteUrl($file);
+
+                $toctreeFiles[] = $absoluteUrl;
+            }
+        }
+
+        return $toctreeFiles;
+    }
+
+    /**
+     * @return string[]
+     */
+    private function parseToctreeFiles(Node $node) : array
+    {
+        $value = (string) $node->getValue();
+
+        return array_filter(array_map('trim', explode("\n", $value)), static function (string $file) {
+            return $file !== '';
+        });
+    }
+
+    /**
+     * @param mixed[] $options
+     */
+    private function isGlob(array $options, string $file) : bool
+    {
+        return isset($options['glob']) && strpos($file, '*') !== false;
+    }
+}

--- a/tests/BuilderTest.php
+++ b/tests/BuilderTest.php
@@ -94,6 +94,20 @@ class BuilderTest extends TestCase
         self::assertContains('subdir/file.html#a-file', $contents);
     }
 
+    public function testToctreeGlobOrder() : void
+    {
+        $contents = $this->getFileContents($this->targetFile('toc-glob.html'));
+
+        // assert `index` is first since it is defined first in toc-glob.rst
+        self::assertContains('<div class="toc"><ul><li id="index-html-summary" class="toc-item"><a href="index.html#summary">Summary</a></li>', $contents);
+
+        // assert `index` is not included and duplicated by the glob
+        self::assertNotContains('</ul><li id="index-html-summary" class="toc-item"><a href="index.html#summary">Summary</a></li>', $contents);
+
+        // assert `introduction` is at the end after the glob since it is defined last in toc-glob.rst
+        self::assertContains('<a href="introduction.html#introduction-page">Introduction page</a></li></ul></div>', $contents);
+    }
+
     public function testToctreeInSubdirectory() : void
     {
         $contents = $this->getFileContents($this->targetFile('subdir/toc.html'));

--- a/tests/GlobSearcherTest.php
+++ b/tests/GlobSearcherTest.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\RST;
+
+use Doctrine\RST\Environment;
+use Doctrine\RST\GlobSearcher;
+use PHPUnit\Framework\TestCase;
+use function sort;
+
+class GlobSearcherTest extends TestCase
+{
+    /** @var GlobSearcher */
+    private $globSearcher;
+
+    public function testGlobSearch() : void
+    {
+        $dir = __DIR__ . '/builder-toctree-glob/input';
+
+        $environment = $this->createMock(Environment::class);
+
+        $environment->expects(self::once())
+            ->method('absoluteRelativePath')
+            ->with('')
+            ->willReturn($dir);
+
+        $environment->expects(self::once())
+            ->method('getDirName')
+            ->willReturn('subdir');
+
+        $files = $this->globSearcher->globSearch($environment, '*');
+
+        self::assertCount(3, $files);
+
+        $expected = [
+            '/not-parsed/file',
+            '/index',
+            '/subdir/toctree',
+        ];
+
+        sort($expected);
+        sort($files);
+
+        self::assertSame($expected, $files);
+    }
+
+    protected function setUp() : void
+    {
+        $this->globSearcher = new GlobSearcher();
+    }
+}

--- a/tests/ToctreeBuilderTest.php
+++ b/tests/ToctreeBuilderTest.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\RST;
+
+use Doctrine\RST\Environment;
+use Doctrine\RST\GlobSearcher;
+use Doctrine\RST\Nodes\Node;
+use Doctrine\RST\ToctreeBuilder;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class ToctreeBuilderTest extends TestCase
+{
+    /** @var GlobSearcher|MockObject */
+    private $globSearcher;
+
+    /** @var ToctreeBuilder */
+    private $toctreeBuilder;
+
+    public function testBuildToctreeFiles() : void
+    {
+        $environment = $this->createMock(Environment::class);
+        $node        = $this->createMock(Node::class);
+        $options     = ['glob' => true];
+
+        $toc = <<<EOF
+test1
+*
+test4
+EOF;
+
+        $node->expects(self::once())
+            ->method('getValue')
+            ->willReturn($toc);
+
+        $environment->expects(self::at(0))
+            ->method('absoluteUrl')
+            ->with('test1')
+            ->willReturn('/test1');
+
+        $this->globSearcher->expects(self::once())
+            ->method('globSearch')
+            ->with($environment, '*')
+            ->willReturn(['/test1', '/test2', '/test3']);
+
+        $environment->expects(self::at(1))
+            ->method('absoluteUrl')
+            ->with('test4')
+            ->willReturn('/test4');
+
+        $toctreeFiles = $this->toctreeBuilder
+            ->buildToctreeFiles($environment, $node, $options);
+
+        $expected = [
+            '/test1',
+            '/test2',
+            '/test3',
+            '/test4',
+        ];
+
+        self::assertSame($expected, $toctreeFiles);
+    }
+
+    protected function setUp() : void
+    {
+        $this->globSearcher = $this->createMock(GlobSearcher::class);
+
+        $this->toctreeBuilder = new ToctreeBuilder($this->globSearcher);
+    }
+}

--- a/tests/builder-fixtures/input/toc-glob.rst
+++ b/tests/builder-fixtures/input/toc-glob.rst
@@ -4,4 +4,6 @@ TOC Glob
 .. toctree::
     :glob:
 
+    index
     *
+    introduction


### PR DESCRIPTION
- [x] fixes #18 - Allow explicit toctree items to be specified before using glob and if glob finds the same items, they do  not get duplicated.