### PR TITLE
Convert standalone URIs and email addresses to links

### DIFF
--- a/tests/HTMLTest.php
+++ b/tests/HTMLTest.php
@@ -29,10 +29,183 @@ class HTMLTest extends TestCase
         self::assertContains('<a href="http://something.com/">', $document);
         self::assertContains('<a href="http://anonymous.com/">', $document);
         self::assertContains('<a href="http://www.github.com/">', $document);
+        self::assertContains('<a href="mailto:jane@example.com">mailto:jane@example.com</a>', $document);
+        self::assertContains('<a href="news:comp.lang.php">news:comp.lang.php</a>', $document);
+        self::assertContains('<a href="http://www.w3.org/Addressing/">http://www.w3.org/Addressing/</a>', $document);
+        self::assertContains('<a href="ftp://foo.example.com/rfc/">ftp://foo.example.com/rfc/</a>', $document);
+        self::assertContains('<a href="http://www.ics.uci.edu/pub/ietf/uri/historical.html#WARNING">http://www.ics.uci.edu/pub/ietf/uri/historical.html#WARNING</a>', $document);
         self::assertContains('under_score', $document);
         self::assertContains(' spacy', $document);
         self::assertNotContains(' ,', $document);
         self::assertNotContains('`', $document);
+    }
+
+    /**
+     * Test that standalone hyperlinks are converted to links
+     */
+    public function testStandaloneHyperlinks() : void
+    {
+        $document = $this->parseHTML('standalone-hyperlinks.rst');
+
+        self::assertContains('<a href="http://daringfireball.net/2010/07/improved_regex_for_matching_urls">http://daringfireball.net/2010/07/improved_regex_for_matching_urls</a>', $document);
+        self::assertContains('<a href="https://daringfireball.net/misc/2010/07/url-matching-regex-test-data.text">https://daringfireball.net/misc/2010/07/url-matching-regex-test-data.text</a>', $document);
+        self::assertContains('<a href="https://mathiasbynens.be/demo/url-regex">https://mathiasbynens.be/demo/url-regex</a>', $document);
+        self::assertContains('<a href="http://foo.com/blah_blah">http://foo.com/blah_blah</a>', $document);
+        self::assertContains('<a href="http://foo.com/blah_blah/">http://foo.com/blah_blah/</a>', $document);
+        self::assertContains('(Something like <a href="http://foo.com/blah_blah">http://foo.com/blah_blah</a>)', $document);
+        self::assertContains('<a href="http://foo.com/(something)?after=parens">http://foo.com/(something)?after=parens</a>', $document);
+        self::assertContains('<a href="http://foo.com/blah_blah">http://foo.com/blah_blah</a>.', $document);
+        self::assertContains('<a href="http://foo.com/blah_blah/">http://foo.com/blah_blah/</a>.', $document);
+        self::assertContains('&lt;<a href="http://foo.com/blah_blah">http://foo.com/blah_blah</a>&gt;', $document);
+        self::assertContains('&lt;<a href="http://foo.com/blah_blah/">http://foo.com/blah_blah/</a>&gt;', $document);
+        self::assertContains('<a href="http://foo.com/blah_blah">http://foo.com/blah_blah</a>,', $document);
+        self::assertContains('<a href="http://www.extinguishedscholar.com/wpglob/?p=364">http://www.extinguishedscholar.com/wpglob/?p=364</a>.', $document);
+        self::assertContains('<a href="http://✪df.ws/1234">http://✪df.ws/1234</a>', $document);
+        self::assertContains('<a href="rdar://1234">rdar://1234</a>', $document);
+        self::assertContains('<a href="rdar:/1234">rdar:/1234</a>', $document);
+        self::assertContains('<a href="x-yojimbo-item://6303E4C1-6A6E-45A6-AB9D-3A908F59AE0E">x-yojimbo-item://6303E4C1-6A6E-45A6-AB9D-3A908F59AE0E</a>', $document);
+        self::assertContains('<a href="message://%3c330e7f840905021726r6a4ba78dkf1fd71420c1bf6ff@mail.gmail.com%3e">message://%3c330e7f840905021726r6a4ba78dkf1fd71420c1bf6ff@mail.gmail.com%3e</a>', $document);
+        self::assertContains('<a href="http://➡.ws/䨹">http://➡.ws/䨹</a>', $document);
+        self::assertContains('&lt;tag&gt;<a href="http://example.com">http://example.com</a>&lt;/tag&gt;', $document);
+        self::assertContains('<a href="http://example.com/something?with,commas,in,url">http://example.com/something?with,commas,in,url</a>, but not at end', $document);
+        self::assertContains('What about &lt;<a href="mailto:gruber@daringfireball.net?subject=TEST">mailto:gruber@daringfireball.net?subject=TEST</a>&gt; (including brokets).', $document);
+        self::assertContains('<a href="mailto:name@example.com">mailto:name@example.com</a>', $document);
+        self::assertContains('<a href="http://www.asianewsphoto.com/(S(neugxif4twuizg551ywh3f55))/Web_ENG/View_DetailPhoto.aspx?PicId=752">http://www.asianewsphoto.com/(S(neugxif4twuizg551ywh3f55))/Web_ENG/View_DetailPhoto.aspx?PicId=752</a>', $document);
+        self::assertContains('<a href="http://www.asianewsphoto.com/(S(neugxif4twuizg551ywh3f55))">http://www.asianewsphoto.com/(S(neugxif4twuizg551ywh3f55))</a>', $document);
+        self::assertContains('<a href="http://lcweb2.loc.gov/cgi-bin/query/h?pp/horyd:@field(NUMBER+@band(thc+5a46634))">http://lcweb2.loc.gov/cgi-bin/query/h?pp/horyd:@field(NUMBER+@band(thc+5a46634))</a>', $document);
+        self::assertContains('<a href="http://www.example.com/wpstyle/?p=364">http://www.example.com/wpstyle/?p=364</a>', $document);
+        self::assertContains('<a href="https://www.example.com/foo/?bar=baz&inga=42&quux">https://www.example.com/foo/?bar=baz&amp;inga=42&amp;quux</a>', $document);
+        self::assertContains('<a href="http://userid:password@example.com:8080">http://userid:password@example.com:8080</a>', $document);
+        self::assertContains('<a href="http://userid:password@example.com:8080/">http://userid:password@example.com:8080/</a>', $document);
+        self::assertContains('<a href="http://userid@example.com">http://userid@example.com</a>', $document);
+        self::assertContains('<a href="http://userid@example.com/">http://userid@example.com/</a>', $document);
+        self::assertContains('<a href="http://userid@example.com:8080">http://userid@example.com:8080</a>', $document);
+        self::assertContains('<a href="http://userid@example.com:8080/">http://userid@example.com:8080/</a>', $document);
+        self::assertContains('<a href="http://userid:password@example.com">http://userid:password@example.com</a>', $document);
+        self::assertContains('<a href="http://userid:password@example.com/">http://userid:password@example.com/</a>', $document);
+        self::assertContains('<a href="http://142.42.1.1/">http://142.42.1.1/</a>', $document);
+        self::assertContains('<a href="http://142.42.1.1:8080/">http://142.42.1.1:8080/</a>', $document);
+        self::assertContains('<a href="http://⌘.ws">http://⌘.ws</a>', $document);
+        self::assertContains('<a href="http://⌘.ws/">http://⌘.ws/</a>', $document);
+        self::assertContains('<a href="http://foo.com/(something)?after=parens">http://foo.com/(something)?after=parens</a>', $document);
+        self::assertContains('<a href="http://☺.damowmow.com/">http://☺.damowmow.com/</a>', $document);
+        self::assertContains('<a href="http://code.google.com/events/#&product=browser">http://code.google.com/events/#&amp;product=browser</a>', $document);
+        self::assertContains('<a href="http://j.mp">http://j.mp</a>', $document);
+        self::assertContains('<a href="ftp://foo.bar/baz">ftp://foo.bar/baz</a>', $document);
+        self::assertContains('<a href="http://foo.bar/?q=Test%20URL-encoded%20stuff">http://foo.bar/?q=Test%20URL-encoded%20stuff</a>', $document);
+        self::assertContains('<a href="http://例子.测试">http://例子.测试</a>', $document);
+        self::assertContains('<a href="http://उदाहरण.परीक्षा">http://उदाहरण.परीक्षा</a>', $document);
+        self::assertContains('<a href="http://-._!$&\'()*+,;=:%40:80%2f::::::@example.com">http://-._!$&amp;\'()*+,;=:%40:80%2f::::::@example.com</a>', $document);
+        self::assertContains('<a href="http://1337.net">http://1337.net</a>', $document);
+        self::assertContains('<a href="http://a.b-c.de">http://a.b-c.de</a>', $document);
+        self::assertContains('<a href="http://223.255.255.254">http://223.255.255.254</a>', $document);
+        self::assertContains('<a href="mailto:jane.doe@example.com">mailto:jane.doe@example.com</a>', $document);
+        self::assertContains('<a href="chrome://chrome">chrome://chrome</a>', $document);
+        self::assertContains('<a href="irc://irc.freenode.net:6667/freenode">irc://irc.freenode.net:6667/freenode</a>', $document);
+        self::assertContains('<a href="microsoft.windows.camera:foobar">microsoft.windows.camera:foobar</a>', $document);
+        self::assertContains('<a href="coaps+ws://foobar">coaps+ws://foobar</a>', $document);
+        self::assertContains('<a href="http://example.com/uris">http://example.com/uris</a>', $document);
+        self::assertContains('<a href="mailto:same-line@example.com">mailto:same-line@example.com</a>', $document);
+
+        self::assertNotContains('<a href="6:00p">', $document);
+        self::assertNotContains('<a href="filename.txt">', $document);
+        self::assertNotContains('<a href="www.c.ws/䨹">', $document);
+        self::assertNotContains('<a href="www.example.com">', $document);
+        self::assertNotContains('<a href="bit.ly/foo">', $document);
+        self::assertNotContains('<a href="is.gd/foo/">', $document);
+        self::assertNotContains('<a href="WWW.EXAMPLE.COM">', $document);
+        self::assertNotContains('<a href="http://">', $document);
+        self::assertNotContains('<a href="http://.">', $document);
+        self::assertNotContains('<a href="http://..">', $document);
+        self::assertNotContains('<a href="http://?">', $document);
+        self::assertNotContains('<a href="http://??">', $document);
+        self::assertNotContains('<a href="//">', $document);
+        self::assertNotContains('<a href="//a">', $document);
+        self::assertNotContains('<a href="///a">', $document);
+        self::assertNotContains('<a href="///">', $document);
+        self::assertNotContains('<a href="foo.com">', $document);
+        self::assertNotContains('<a href="h://test">', $document);
+        self::assertNotContains('<a href="http:// shouldfail.com">', $document);
+        self::assertNotContains('<a href=":// should fail">', $document);
+        self::assertNotContains('<a href="✪df.ws/1234">', $document);
+        self::assertNotContains('<a href="example.com">', $document);
+        self::assertNotContains('<a href="example.com/">', $document);
+    }
+
+    /**
+     * Tests that hyperlinks that contain underscores are not mangled by the parser
+     *
+     * We are skipping these assertions for now because the parser is being
+     * confused by the underscores (i.e. "blah_"), thinking that they are inline
+     * named links.
+     */
+    public function testStandaloneHyperlinksWithUnderscores() : void
+    {
+        self::markTestSkipped('Skipping due to broken parsing of standalone hyperlinks.');
+
+        $document = $this->parseHTML('standalone-hyperlinks.rst');
+
+        self::assertContains('<a href="http://foo.com/blah_blah_(wikipedia)">http://foo.com/blah_blah_(wikipedia)</a>', $document);
+        self::assertContains('<a href="http://foo.com/blah_blah_(wikipedia)_(again)">http://foo.com/blah_blah_(wikipedia)_(again)</a>', $document);
+        self::assertContains('<a href="http://foo.com/more_(than)_one_(parens)">http://foo.com/more_(than)_one_(parens)</a>', $document);
+        self::assertContains('<a href="http://foo.com/blah_(wikipedia)#cite-1">http://foo.com/blah_(wikipedia)#cite-1</a>', $document);
+        self::assertContains('<a href="http://foo.com/blah_(wikipedia)_blah#cite-1">http://foo.com/blah_(wikipedia)_blah#cite-1</a>', $document);
+        self::assertContains('<a href="http://foo.com/unicode_(✪)_in_parens">http://foo.com/unicode_(✪)_in_parens</a>', $document);
+    }
+
+    /**
+     * Test that standalone email addresses are converted to links
+     */
+    public function testStandaloneEmailAddresses() : void
+    {
+        $document = $this->parseHTML('standalone-email-addresses.rst');
+
+        self::assertContains('<a href="mailto:jdoe@machine1.example">jdoe@machine1.example</a>', $document);
+        self::assertContains('<a href="mailto:mjones@machine1.example">mjones@machine1.example</a>', $document);
+        self::assertContains('<a href="mailto:mary@example1.net">mary@example1.net</a>', $document);
+        self::assertContains('<a href="mailto:1234@local.machine.example">1234@local.machine.example</a>', $document);
+        self::assertContains('<a href="mailto:john.q.public@example.com">john.q.public@example.com</a>', $document);
+        self::assertContains('<a href="mailto:mary@x.test">mary@x.test</a>', $document);
+        self::assertContains('<a href="mailto:jdoe@example.org">jdoe@example.org</a>', $document);
+        self::assertContains('<a href="mailto:one@y.test">one@y.test</a>', $document);
+        self::assertContains('<a href="mailto:boss@nil.test">boss@nil.test</a>', $document);
+        self::assertContains('<a href="mailto:sysservices@example.net">sysservices@example.net</a>', $document);
+        self::assertContains('<a href="mailto:5678.21-Nov-1997@example.com">5678.21-Nov-1997@example.com</a>', $document);
+        self::assertContains('<a href="mailto:pete@silly.example">pete@silly.example</a>', $document);
+        self::assertContains('<a href="mailto:c@a.test">c@a.test</a>', $document);
+        self::assertContains('<a href="mailto:joe@where.test">joe@where.test</a>', $document);
+        self::assertContains('<a href="mailto:jdoe@one1.test">jdoe@one1.test</a>', $document);
+        self::assertContains('<a href="mailto:testabcd.1234@silly.example">testabcd.1234@silly.example</a>', $document);
+        self::assertContains('<a href="mailto:smith@home.example">smith@home.example</a>', $document);
+        self::assertContains('<a href="mailto:jdoe@machine2.example">jdoe@machine2.example</a>', $document);
+        self::assertContains('<a href="mailto:abcd.1234@local.machine.test">abcd.1234@local.machine.test</a>', $document);
+        self::assertContains('<a href="mailto:3456@example.net">3456@example.net</a>', $document);
+        self::assertContains('<a href="mailto:1235@local.machine.example">1235@local.machine.example</a>', $document);
+        self::assertContains('<a href="mailto:3457@example.net">3457@example.net</a>', $document);
+        self::assertContains('<a href="mailto:mary@example2.net">mary@example2.net</a>', $document);
+        self::assertContains('<a href="mailto:j-brown@other.example">j-brown@other.example</a>', $document);
+        self::assertContains('<a href="mailto:78910@example.net">78910@example.net</a>', $document);
+        self::assertContains('<a href="mailto:jdoe@machine3.example">jdoe@machine3.example</a>', $document);
+        self::assertContains('<a href="mailto:mary@example3.net">mary@example3.net</a>', $document);
+        self::assertContains('<a href="mailto:1236@local.machine.example">1236@local.machine.example</a>', $document);
+        self::assertContains('<a href="mailto:mary@example4.net">mary@example4.net</a>', $document);
+        self::assertContains('<a href="mailto:jdoe@node.example">jdoe@node.example</a>', $document);
+        self::assertContains('<a href="mailto:mary@example5.net">mary@example5.net</a>', $document);
+        self::assertContains('<a href="mailto:1236@local.node.example">1236@local.node.example</a>', $document);
+        self::assertContains('<a href="mailto:joe@example.org">joe@example.org</a>', $document);
+        self::assertContains('<a href="mailto:jdoe@one2.test">jdoe@one2.test</a>', $document);
+        self::assertContains('<a href="mailto:testabcd.1234@silly.test">testabcd.1234@silly.test</a>', $document);
+        self::assertContains('<a href="mailto:foo+bar@test.email.address">foo+bar@test.email.address</a>', $document);
+        self::assertContains('<a href="mailto:foo.bar-baz_quux@example-foo.quux">foo.bar-baz_quux@example-foo.quux</a>', $document);
+        self::assertContains('<a href="mailto:foo%20bar@example.testareallylongtldinanemailaddress">foo%20bar@example.testareallylongtldinanemailaddress</a>', $document);
+
+        self::assertNotContains('<a href="mailto:pete(his account)@silly.test(his host)">', $document);
+        self::assertNotContains('<a href="mailto:c@(Chris\'s host.)public.example">', $document);
+        self::assertNotContains('<a href="mailto:foo@example.">', $document);
+        self::assertNotContains('<a href="mailto:foo@example">', $document);
+        self::assertNotContains('<a href="mailto:@example.com">', $document);
+        self::assertNotContains('<a href="mailto:@example">', $document);
+        self::assertNotContains('<a href="mailto:foo.bar-baz_quux@example-foo_bar.quux">', $document);
     }
 
     /**

--- a/tests/html/links.rst
+++ b/tests/html/links.rst
@@ -13,5 +13,12 @@ I love GitHub__
 
 This is a under_score that is not supposed to be used
 
+You can send mail to mailto:jane@example.com or use the news group at
+news:comp.lang.php.
+
+Yes, Jim, I found it under "http://www.w3.org/Addressing/", but you can probably
+pick it up from <ftp://foo.example.com/rfc/>.  Note the warning in
+<http://www.ics.uci.edu/pub/ietf/uri/historical.html#WARNING>.
+
 .. _`xkcd`: http://xkcd.com/
 .. _something: http://something.com/

--- a/tests/html/standalone-email-addresses.rst
+++ b/tests/html/standalone-email-addresses.rst
@@ -1,0 +1,128 @@
+Addressing examples taken from https://tools.ietf.org/html/rfc5322.
+
+Appendix A.1.1.  A Message from One Person to Another with Simple Addressing
+
+   ----
+   From: John Doe <jdoe@machine1.example>
+   Sender: Michael Jones <mjones@machine1.example>
+   To: Mary Smith <mary@example1.net>
+   Subject: Saying Hello
+   Date: Fri, 21 Nov 1997 09:55:06 -0600
+   Message-ID: <1234@local.machine.example>
+
+   This is a message just to say hello.
+   So, "Hello".
+   ----
+
+Appendix A.1.2.  Different Types of Mailboxes
+
+   ----
+   From: "Joe Q. Public" <john.q.public@example.com>
+   To: Mary Smith <mary@x.test>, jdoe@example.org, Who? <one@y.test>
+   Cc: <boss@nil.test>, "Giant; \"Big\" Box" <sysservices@example.net>
+   Date: Tue, 1 Jul 2003 10:52:37 +0200
+   Message-ID: <5678.21-Nov-1997@example.com>
+
+   Hi everyone.
+   ----
+
+Appendix A.1.3.  Group Addresses
+
+   ----
+   From: Pete <pete@silly.example>
+   To: A Group:Ed Jones <c@a.test>,joe@where.test,John <jdoe@one1.test>;
+   Cc: Undisclosed recipients:;
+   Date: Thu, 13 Feb 1969 23:32:54 -0330
+   Message-ID: <testabcd.1234@silly.example>
+
+   Testing.
+   ----
+
+Appendix A.2.  Reply Messages
+
+   ----
+   To: "Mary Smith: Personal Account" <smith@home.example>
+   From: John Doe <jdoe@machine2.example>
+   Subject: Re: Saying Hello
+   Date: Fri, 21 Nov 1997 11:00:00 -0600
+   Message-ID: <abcd.1234@local.machine.test>
+   In-Reply-To: <3456@example.net>
+   References: <1235@local.machine.example> <3457@example.net>
+
+   This is a reply to your reply.
+   ----
+
+Appendix A.3.  Resent Messages
+
+   ----
+   Resent-From: Mary Smith <mary@example2.net>
+   Resent-To: Jane Brown <j-brown@other.example>
+   Resent-Date: Mon, 24 Nov 1997 14:22:01 -0800
+   Resent-Message-ID: <78910@example.net>
+   From: John Doe <jdoe@machine3.example>
+   To: Mary Smith <mary@example3.net>
+   Subject: Saying Hello
+   Date: Fri, 21 Nov 1997 09:55:06 -0600
+   Message-ID: <1236@local.machine.example>
+
+   This is a message just to say hello.
+   So, "Hello".
+   ----
+
+Appendix A.4.  Messages with Trace Fields
+
+   ----
+   Received: from x.y.test
+      by example.net
+      via TCP
+      with ESMTP
+      id ABC12345
+      for <mary@example4.net>;  21 Nov 1997 10:05:43 -0600
+   Received: from node.example by x.y.test; 21 Nov 1997 10:01:22 -0600
+   From: John Doe <jdoe@node.example>
+   To: Mary Smith <mary@example5.net>
+   Subject: Saying Hello
+   Date: Fri, 21 Nov 1997 09:55:06 -0600
+   Message-ID: <1236@local.node.example>
+
+   This is a message just to say hello.
+   So, "Hello".
+   ----
+
+Appendix A.5.  White Space, Comments, and Other Oddities
+
+The addresses here are perfectly legal, according to RFC 5322, but we're not
+going to support all these formats.
+
+   ----
+   From: Pete(A nice \) chap) <pete(his account)@silly.test(his host)>
+   To:A Group(Some people)
+        :Chris Jones <c@(Chris's host.)public.example>,
+            joe@example.org,
+     John <jdoe@one2.test> (my dear friend); (the end of the group)
+   Cc:(Empty list)(start)Hidden recipients  :(nobody(that I know))  ;
+   Date: Thu,
+         13
+           Feb
+             1969
+         23:32
+                  -0330 (Newfoundland Time)
+   Message-ID:              <testabcd.1234@silly.test>
+
+   Testing.
+   ----
+
+
+More addresses that should be matched:
+
+    foo+bar@test.email.address
+    foo.bar-baz_quux@example-foo.quux
+    foo%20bar@example.testareallylongtldinanemailaddress
+
+
+These should not be matched:
+
+    This is not an email address foo@example.
+    Also not one: @example.com text on other side of it
+    Another non-address @example foo bar baz
+    foo.bar-baz_quux@example-foo_bar.quux

--- a/tests/html/standalone-hyperlinks.rst
+++ b/tests/html/standalone-hyperlinks.rst
@@ -1,0 +1,103 @@
+Test data for the URL-matching regex pattern presented here:
+
+http://daringfireball.net/2010/07/improved_regex_for_matching_urls
+
+This list of URLs is adapted from
+https://daringfireball.net/misc/2010/07/url-matching-regex-test-data.text and
+https://mathiasbynens.be/demo/url-regex.
+
+
+Matches the right thing in the following lines:
+
+    http://foo.com/blah_blah
+    http://foo.com/blah_blah/
+    (Something like http://foo.com/blah_blah)
+    http://foo.com/(something)?after=parens
+    http://foo.com/blah_blah.
+    http://foo.com/blah_blah/.
+    <http://foo.com/blah_blah>
+    <http://foo.com/blah_blah/>
+    http://foo.com/blah_blah,
+    http://www.extinguishedscholar.com/wpglob/?p=364.
+    http://✪df.ws/1234
+    rdar://1234
+    rdar:/1234
+    x-yojimbo-item://6303E4C1-6A6E-45A6-AB9D-3A908F59AE0E
+    message://%3c330e7f840905021726r6a4ba78dkf1fd71420c1bf6ff@mail.gmail.com%3e
+    http://➡.ws/䨹
+    <tag>http://example.com</tag>
+    http://example.com/something?with,commas,in,url, but not at end
+    What about <mailto:gruber@daringfireball.net?subject=TEST> (including brokets).
+    mailto:name@example.com
+    http://www.asianewsphoto.com/(S(neugxif4twuizg551ywh3f55))/Web_ENG/View_DetailPhoto.aspx?PicId=752
+    http://www.asianewsphoto.com/(S(neugxif4twuizg551ywh3f55))
+    http://lcweb2.loc.gov/cgi-bin/query/h?pp/horyd:@field(NUMBER+@band(thc+5a46634))
+    http://www.example.com/wpstyle/?p=364
+    https://www.example.com/foo/?bar=baz&inga=42&quux
+    http://userid:password@example.com:8080
+    http://userid:password@example.com:8080/
+    http://userid@example.com
+    http://userid@example.com/
+    http://userid@example.com:8080
+    http://userid@example.com:8080/
+    http://userid:password@example.com
+    http://userid:password@example.com/
+    http://142.42.1.1/
+    http://142.42.1.1:8080/
+    http://⌘.ws
+    http://⌘.ws/
+    http://☺.damowmow.com/
+    http://code.google.com/events/#&product=browser
+    http://j.mp
+    ftp://foo.bar/baz
+    http://foo.bar/?q=Test%20URL-encoded%20stuff
+    http://例子.测试
+    http://उदाहरण.परीक्षा
+    http://-._!$&'()*+,;=:%40:80%2f::::::@example.com
+    http://1337.net
+    http://a.b-c.de
+    http://223.255.255.254
+    mailto:jane.doe@example.com
+    chrome://chrome
+    irc://irc.freenode.net:6667/freenode
+    microsoft.windows.camera:foobar
+    coaps+ws://foobar
+    How about multiple http://example.com/uris on the mailto:same-line@example.com
+
+
+Should fail against:
+    6:00p
+    filename.txt
+    www.c.ws/䨹
+    Just a www.example.com link.
+    bit.ly/foo
+    “is.gd/foo/”
+    WWW.EXAMPLE.COM
+    http://
+    http://.
+    http://..
+    http://?
+    http://??
+    //
+    //a
+    ///
+    foo.com
+    h://test
+    http:// shouldfail.com
+    :// should fail
+    ✪df.ws/1234
+    example.com
+    example.com/
+
+
+These are currently problematic and fail, since the parser appears to see named
+links appearing within these URLs (i.e. "blah_") and attempts to replace these
+with tokens. These should match the standalone hyperlink pattern, but they do
+not at this time.
+
+    http://foo.com/blah_blah_(wikipedia)
+    (Something like http://foo.com/blah_blah_(wikipedia))
+    http://foo.com/more_(than)_one_(parens)
+    http://foo.com/blah_(wikipedia)#cite-1
+    http://foo.com/blah_(wikipedia)_blah#cite-1
+    http://foo.com/unicode_(✪)_in_parens


### PR DESCRIPTION
According to the reStructuredText Markup Specification:

> A URI (absolute URI or standalone email address) within a text block is treated as a general external hyperlink with the URI itself as the link's text. ([ref])

This PR adds support for finding standalone URIs and email addresses and converting them to links.


[ref]: http://docutils.sourceforge.net/docs/ref/rst/restructuredtext.html#standalone-hyperlinks