### PR TITLE
Fix issue when a link is on multiple lines.

### DIFF
--- a/lib/Renderers/SpanNodeRenderer.php
+++ b/lib/Renderers/SpanNodeRenderer.php
@@ -10,6 +10,7 @@ use Doctrine\RST\Nodes\Node;
 use Doctrine\RST\Nodes\SpanNode;
 use Doctrine\RST\Span\SpanToken;
 use InvalidArgumentException;
+use function is_string;
 use function preg_replace;
 use function preg_replace_callback;
 use function sprintf;
@@ -83,11 +84,19 @@ abstract class SpanNodeRenderer implements NodeRenderer, SpanRenderer
         return preg_replace_callback('/\|(.+)\|/mUsi', function (array $match) : string {
             $variable = $this->environment->getVariable($match[1]);
 
+            if ($variable === null) {
+                return '';
+            }
+
             if ($variable instanceof Node) {
                 return $variable->render();
             }
 
-            return $variable;
+            if (is_string($variable)) {
+                return $variable;
+            }
+
+            return (string) $variable;
         }, $span);
     }
 

--- a/lib/Span/SpanProcessor.php
+++ b/lib/Span/SpanProcessor.php
@@ -152,7 +152,7 @@ class SpanProcessor
             $next = $match[6];
             $url  = '';
 
-            if (preg_match('/^(.+) <(.+)>$/mUsi', $link, $m) > 0) {
+            if (preg_match('/^(.+)[ \n]<(.+)>$/mUsi', $link, $m) > 0) {
                 $link = $m[1];
                 $url  = $m[2];
 

--- a/tests/HTML/HTMLTest.php
+++ b/tests/HTML/HTMLTest.php
@@ -24,6 +24,7 @@ class HTMLTest extends TestCase
     {
         $document = $this->parseHTML('links.rst');
 
+        self::assertContains('<a href="http://docs.doctrine-project.org/en/latest/tutorials/embeddables.html">in the documentation</a>', $document);
         self::assertContains('<a href="http://www.google.com/">', $document);
         self::assertContains('<a href="http://xkcd.com/">', $document);
         self::assertContains('<a href="http://something.com/">', $document);

--- a/tests/HTML/files/links.rst
+++ b/tests/HTML/files/links.rst
@@ -20,5 +20,8 @@ Yes, Jim, I found it under "http://www.w3.org/Addressing/", but you can probably
 pick it up from <ftp://foo.example.com/rfc/>.  Note the warning in
 <http://www.ics.uci.edu/pub/ietf/uri/historical.html#WARNING>.
 
+You can read more on the features of Embeddables objects `in the documentation
+<http://docs.doctrine-project.org/en/latest/tutorials/embeddables.html>`_.
+
 .. _`xkcd`: http://xkcd.com/
 .. _something: http://something.com/


### PR DESCRIPTION
After we started surfacing more visibility to broken links and references, I discovered this bug. Links that exist on multiple lines aren't being parsed correctly.

Confirmed this bug exists in Gregwar/RST too here: https://github.com/Gregwar/RST/blob/master/Span.php#L99
