### PR TITLE
handle link with new line inside list

### DIFF
--- a/lib/Span/SpanProcessor.php
+++ b/lib/Span/SpanProcessor.php
@@ -9,6 +9,7 @@ use function htmlspecialchars;
 use function mt_rand;
 use function preg_match;
 use function preg_match_all;
+use function preg_replace;
 use function preg_replace_callback;
 use function sha1;
 use function str_replace;
@@ -147,11 +148,13 @@ class SpanProcessor
         }
 
         $linkCallback = function (array $match) : string {
+            /** @var string $link */
             $link = $match[3] ?: $match[5];
 
             // the link may have a new line in it so we need to strip it
             // before setting the link and adding a token to be replaced
             $link = str_replace("\n", ' ', $link);
+            $link = preg_replace('/\s+/', ' ', $link);
 
             // we need to maintain the characters before and after the link
             $prev = $match[1]; // previous character before the link

--- a/tests/HTML/HTMLTest.php
+++ b/tests/HTML/HTMLTest.php
@@ -569,6 +569,18 @@ class HTMLTest extends TestCase
         );
     }
 
+    public function testLinkWithNewLineInsideList() : void
+    {
+        $document = $this->parse('link-with-new-line-inside-list.rst');
+
+        $rendered = $document->renderDocument();
+
+        self::assertContains(
+            '<a href="https://www.doctrine-project.org/projects/rst-parser.html">link to the doc</a>',
+            $rendered
+        );
+    }
+
     public function testLinkWithNoName() : void
     {
         $document = $this->parse('link-with-no-name.rst');

--- a/tests/HTML/files/link-with-new-line-inside-list.rst
+++ b/tests/HTML/files/link-with-new-line-inside-list.rst
@@ -1,0 +1,5 @@
+- see `link to
+  the doc`_
+- list item 2
+
+.. _`link to the doc`: https://www.doctrine-project.org/projects/rst-parser.html


### PR DESCRIPTION
This PR fixes the error when a link with new line is nested in a list:
```RST
- Self hosting: create your own repository and access it either through the
  filesystem or the network. To help in this task you can read `Version Control
  with Subversion`_.
```