### PR TITLE
add failing test for links when name contains "::"

### DIFF
--- a/lib/Parser/DocumentParser.php
+++ b/lib/Parser/DocumentParser.php
@@ -221,13 +221,13 @@ class DocumentParser
                             $this->setState(State::BLOCK);
                         }
                         return false;
+                    } elseif ($this->parseLink($line)) {
+                        return true;
                     } elseif ($this->lineChecker->isDirective($line)) {
                         $this->setState(State::DIRECTIVE);
                         $this->buffer = new Buffer();
                         $this->flush();
                         $this->initDirective($line);
-                    } elseif ($this->parseLink($line)) {
-                        return true;
                     } elseif ($this->lineChecker->isDefinitionList($this->lines->getNextLine())) {
                         $this->setState(State::DEFINITION_LIST);
                         $this->buffer->push($line);

--- a/lib/Parser/LineChecker.php
+++ b/lib/Parser/LineChecker.php
@@ -70,7 +70,7 @@ class LineChecker
 
     public function isDirective(string $line) : bool
     {
-        return preg_match('/^\.\. (\|(.+)\| |)([^\s]+)::(.*)$/mUsi', $line) > 0;
+        return preg_match('/^\.\. (\|(.+)\| |)([^\s]+)::( (.*)|)$/mUsi', $line) > 0;
     }
 
     public function isDefinitionList(string $line) : bool

--- a/tests/HTML/HTMLTest.php
+++ b/tests/HTML/HTMLTest.php
@@ -591,6 +591,11 @@ class HTMLTest extends TestCase
             '<a href="https://php.net/manual/en/class.intldateformatter.php#intl.intldateformatter-constants">IntlDateFormatter::MEDIUM</a>',
             $rendered
         );
+
+        self::assertContains(
+            '<a href="https://php.net/manual/en/class.intldateformatter.php#intl.intldateformatter-constants">IntlDateFormatter:: MEDIUM</a>',
+            $rendered
+        );
     }
 
     /**

--- a/tests/HTML/HTMLTest.php
+++ b/tests/HTML/HTMLTest.php
@@ -581,6 +581,18 @@ class HTMLTest extends TestCase
         );
     }
 
+    public function testLinkWithSpecialChar() : void
+    {
+        $document = $this->parse('link-with-special-char.rst');
+
+        $rendered = $document->renderDocument();
+
+        self::assertContains(
+            '<a href="https://php.net/manual/en/class.intldateformatter.php#intl.intldateformatter-constants">IntlDateFormatter::MEDIUM</a>',
+            $rendered
+        );
+    }
+
     /**
      * Helper function, parses a file and returns the document
      * produced by the parser

--- a/tests/HTML/files/link-with-special-char.rst
+++ b/tests/HTML/files/link-with-special-char.rst
@@ -1,0 +1,3 @@
+`IntlDateFormatter::MEDIUM`_
+
+.. _`IntlDateFormatter::MEDIUM`: https://php.net/manual/en/class.intldateformatter.php#intl.intldateformatter-constants

--- a/tests/HTML/files/link-with-special-char.rst
+++ b/tests/HTML/files/link-with-special-char.rst
@@ -1,3 +1,6 @@
 `IntlDateFormatter::MEDIUM`_
+`IntlDateFormatter:: MEDIUM`_
 
 .. _`IntlDateFormatter::MEDIUM`: https://php.net/manual/en/class.intldateformatter.php#intl.intldateformatter-constants
+
+.. _`IntlDateFormatter:: MEDIUM`: https://php.net/manual/en/class.intldateformatter.php#intl.intldateformatter-constants

--- a/tests/Parser/LineCheckerTest.php
+++ b/tests/Parser/LineCheckerTest.php
@@ -68,6 +68,13 @@ class LineCheckerTest extends TestCase
     public function testIsDirective() : void
     {
         self::assertTrue($this->lineChecker->isDirective('.. code-block::'));
+        self::assertTrue($this->lineChecker->isDirective('.. code-block:: php'));
+        self::assertTrue($this->lineChecker->isDirective('.. code&block:: php'));
+        self::assertTrue($this->lineChecker->isDirective('.. `code-block`:: php'));
+        self::assertFalse($this->lineChecker->isDirective('.. code block:: php'));
+        self::assertFalse($this->lineChecker->isDirective('.. code block :: php'));
+        self::assertFalse($this->lineChecker->isDirective('..code block:: php'));
+        self::assertFalse($this->lineChecker->isDirective('.. code-block::php'));
         self::assertFalse($this->lineChecker->isDirective('Test'));
     }
 

--- a/tests/Parser/LineDataParserTest.php
+++ b/tests/Parser/LineDataParserTest.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\RST\Parser;
+
+use Doctrine\RST\Parser;
+use Doctrine\RST\Parser\LineDataParser;
+use Doctrine\RST\Parser\Link;
+use PHPUnit\Framework\TestCase;
+
+class LineDataParserTest extends TestCase
+{
+    /** @var Parser */
+    private $parser;
+
+    /** @var LineDataParser */
+    private $lineDataParser;
+
+    /**
+     * @param mixed $expected
+     *
+     * @dataProvider getTestLinks
+     */
+    public function testParseLink(string $line, $expected) : void
+    {
+        self::assertEquals($expected, $this->lineDataParser->parseLink($line));
+    }
+
+    /**
+     * @return mixed[]
+     */
+    public function getTestLinks() : array
+    {
+        return [
+            ['', null],
+            ['test', null],
+            ['.. test', null],
+            ['.. _test', null],
+            ['.. _test: https://www.google.com', new Link('test', 'https://www.google.com', Link::TYPE_LINK)],
+            ['.. _`test`: https://www.google.com', new Link('test', 'https://www.google.com', Link::TYPE_LINK)],
+            ['__ https://www.google.com', new Link('_', 'https://www.google.com', Link::TYPE_LINK)],
+            ['.. _anchor:', new Link('anchor', '#anchor', Link::TYPE_ANCHOR)],
+        ];
+    }
+
+    protected function setUp() : void
+    {
+        $this->parser = $this->createMock(Parser::class);
+
+        $this->lineDataParser = new LineDataParser($this->parser);
+    }
+}


### PR DESCRIPTION
Hi,

here is a failing test case with this case which creates an error:

```RST
`IntlDateFormatter::MEDIUM`_
.. _`IntlDateFormatter::MEDIUM`: https://php.net/manual/en/class.intldateformatter.php#intl.intldateformatter-constants
```

Actually, the link is proccessed by `SpanProcessor` and the token is added, but the link does not added to the environment because this regex does not match: https://github.com/doctrine/rst-parser/blob/master/lib/Parser/LineDataParser.php#L29

which is odd because when i'm checking with some regex tool, it matches...
https://regex101.com/r/BDqL7Z/1