### PR TITLE
Titles could be only 2 characters long

### DIFF
--- a/lib/Parser/LineChecker.php
+++ b/lib/Parser/LineChecker.php
@@ -24,7 +24,7 @@ class LineChecker
 
     public function isSpecialLine(string $line) : ?string
     {
-        if (strlen($line) < 3) {
+        if (strlen($line) < 2) {
             return null;
         }
 

--- a/tests/Builder/BuilderTest.php
+++ b/tests/Builder/BuilderTest.php
@@ -250,6 +250,16 @@ class BuilderTest extends BaseBuilderTest
         }
     }
 
+    public function testReferenceToTitleWith2CharactersLong() : void
+    {
+        $contents = $this->getFileContents($this->targetFile('subdir/test.html'));
+
+        self::assertContains(
+            '<a href="subdir/test.html#em">em</a>',
+            $contents
+        );
+    }
+
     protected function getFixturesDirectory() : string
     {
         return 'Builder';

--- a/tests/Builder/input/subdir/index.rst
+++ b/tests/Builder/input/subdir/index.rst
@@ -56,3 +56,8 @@ Reference absolute to the :doc:`/index`
 .. include:: /subdir/include.rst.inc
 
 .. include:: include.rst.inc
+
+`em`_
+
+em
+--

--- a/tests/HTML/HTMLTest.php
+++ b/tests/HTML/HTMLTest.php
@@ -404,8 +404,8 @@ class HTMLTest extends TestCase
 
         self::assertSame(1, substr_count($document, '<h1>'));
         self::assertSame(1, substr_count($document, '<h1>'));
-        self::assertSame(2, substr_count($document, '<h2>'));
-        self::assertSame(2, substr_count($document, '</h2>'));
+        self::assertSame(3, substr_count($document, '<h2>'));
+        self::assertSame(3, substr_count($document, '</h2>'));
         self::assertSame(4, substr_count($document, '<h3>'));
         self::assertSame(4, substr_count($document, '</h3>'));
         self::assertContains('<a id="main-title"></a><h1>Main title</h1>', $document);
@@ -414,6 +414,7 @@ class HTMLTest extends TestCase
         self::assertContains('<a id="second-subsubtitle"></a><h3>Second subsubtitle</h3>', $document);
         self::assertContains('<a id="third-subsubtitle"></a><h3>Third subsubtitle</h3>', $document);
         self::assertContains('<a id="fourth-subsubtitle"></a><h3>Fourth subsubtitle</h3>', $document);
+        self::assertContains('<a id="em"></a><h2>em</h2>', $document);
         self::assertNotContains('==', $document);
         self::assertNotContains('--', $document);
         self::assertNotContains('~~', $document);

--- a/tests/HTML/files/titles.rst
+++ b/tests/HTML/files/titles.rst
@@ -26,3 +26,6 @@ Text again
 Fourth subsubtitle
 ~~~~~~~~~~~~~~~~~~
 
+em
+--
+

--- a/tests/Parser/LineCheckerTest.php
+++ b/tests/Parser/LineCheckerTest.php
@@ -30,7 +30,8 @@ class LineCheckerTest extends TestCase
      */
     public function testIsSpecialLine(string $specialCharacter) : void
     {
-        self::assertNull($this->lineChecker->isSpecialLine(str_repeat($specialCharacter, 2)));
+        self::assertNull($this->lineChecker->isSpecialLine($specialCharacter));
+        self::assertSame($specialCharacter, $this->lineChecker->isSpecialLine(str_repeat($specialCharacter, 2)));
         self::assertSame($specialCharacter, $this->lineChecker->isSpecialLine(str_repeat($specialCharacter, 3)));
     }
 
@@ -39,7 +40,7 @@ class LineCheckerTest extends TestCase
      */
     public function getSpecialCharacters() : array
     {
-        return [['='], ['-'], ['~'], ['*'], ['+'], ['^'], ['"']];
+        return [['='], ['-'], ['~'], ['*'], ['+'], ['^'], ['"'], ['.'], ['`'], ["'"], ['_'], ['#'], [':']];
     }
 
     public function testIsListLine() : void


### PR DESCRIPTION
Hi,

here is a fix for this case which created some errors:
```rst
`em`_
em
--
```
actually 2 characters long titles are not parsed into title...