### PR TITLE
Throwing an unknown directive earlier and with more info

### DIFF
--- a/lib/Parser/DocumentParser.php
+++ b/lib/Parser/DocumentParser.php
@@ -531,14 +531,6 @@ class DocumentParser
 
         $name = $this->directive->getName();
 
-        if (! isset($this->directives[$name])) {
-            $message = 'Unknown directive: ' . $name;
-
-            $this->environment->getErrorManager()->error($message);
-
-            return null;
-        }
-
         return $this->directives[$name];
     }
 
@@ -563,13 +555,21 @@ class DocumentParser
     {
         $parserDirective = $this->lineDataParser->parseDirective($line);
 
-        if ($parserDirective !== null) {
-            $this->directive = $parserDirective;
-
-            return true;
+        if ($parserDirective === null) {
+            return false;
         }
 
-        return false;
+        if (! isset($this->directives[$parserDirective->getName()])) {
+            $message = sprintf('Unknown directive: "%s" in "%s" for line "%s"', $parserDirective->getName(), $this->environment->getCurrentFileName(), $line);
+
+            $this->environment->getErrorManager()->error($message);
+
+            return false;
+        }
+
+        $this->directive = $parserDirective;
+
+        return true;
     }
 
     private function prepareCode() : bool

--- a/tests/Functional/tests/main-directive/main-directive.html
+++ b/tests/Functional/tests/main-directive/main-directive.html
@@ -1,2 +1,2 @@
 Exception: Exception
-Unknown directive: latex-main
+Unknown directive: "latex-main"

--- a/tests/Functional/tests/unknown-directive/unknown-directive.html
+++ b/tests/Functional/tests/unknown-directive/unknown-directive.html
@@ -1,2 +1,2 @@
 Exception: Exception
-Unknown directive: unknown-directive
+Unknown directive: "unknown-directive"


### PR DESCRIPTION
Relates to #71 - this solves it in just one case... and it may be that we just need to add this contextual information piece-by-piece.

The if statement was moved because, before, it would find the directive, set it, then only explode LATER. This makes it explode as soon as it finds a directive that it doesn't know about (which allows us to print more contextual information).