### PR TITLE
adding test case for sections closing too far

### DIFF
--- a/lib/Parser/DocumentParser.php
+++ b/lib/Parser/DocumentParser.php
@@ -20,6 +20,7 @@ use Doctrine\RST\Parser\Directive as ParserDirective;
 use Exception;
 use Throwable;
 
+use function array_reverse;
 use function array_search;
 use function assert;
 use function chr;
@@ -484,9 +485,14 @@ class DocumentParser
                     );
 
                     if ($this->lastTitleNode !== null) {
-                        // current level is less than previous so we need to end all open sections
+                        // current level is less than previous so we need to
+                        // end previous open sections with a greater or equal level
                         if ($node->getLevel() < $this->lastTitleNode->getLevel()) {
-                            foreach ($this->openTitleNodes as $titleNode) {
+                            foreach (array_reverse($this->openTitleNodes) as $titleNode) {
+                                if ($node->getLevel() > $titleNode->getLevel()) {
+                                    break;
+                                }
+
                                 $this->endOpenSection($titleNode);
                             }
                         // same level as the last so just close the last open section

--- a/tests/Functional/tests/section-nesting/section-nesting.html
+++ b/tests/Functional/tests/section-nesting/section-nesting.html
@@ -47,4 +47,9 @@
             </h3>
         </div>
     </div>
+    <div class="section" id="level-2-test-4b">
+        <h2>
+            Level 2 Test 4b
+        </h2>
+    </div>
 </div>

--- a/tests/Functional/tests/section-nesting/section-nesting.rst
+++ b/tests/Functional/tests/section-nesting/section-nesting.rst
@@ -27,3 +27,6 @@ Level 2 Test 3
 
 Level 3 Test 1
 **************
+
+Level 2 Test 4b
+---------------

--- a/tests/Functional/tests/titles-auto/titles-auto.html
+++ b/tests/Functional/tests/titles-auto/titles-auto.html
@@ -19,20 +19,20 @@
             </h3>
         </div>
     </div>
-</div>
-<div class="section" id="second-subtitle">
-    <h2>
-        Second subtitle
-    </h2>
-    <div class="section" id="third-subsubtitle">
-        <h3>
-            Third subsubtitle
-        </h3>
-        <p>Text again</p>
-    </div>
-    <div class="section" id="fourth-subsubtitle">
-        <h3>
-            Fourth subsubtitle
-        </h3>
+    <div class="section" id="second-subtitle">
+        <h2>
+            Second subtitle
+        </h2>
+        <div class="section" id="third-subsubtitle">
+            <h3>
+                Third subsubtitle
+            </h3>
+            <p>Text again</p>
+        </div>
+        <div class="section" id="fourth-subsubtitle">
+            <h3>
+                Fourth subsubtitle
+            </h3>
+        </div>
     </div>
 </div>

--- a/tests/Functional/tests/titles/titles.html
+++ b/tests/Functional/tests/titles/titles.html
@@ -20,27 +20,27 @@
             </h3>
         </div>
     </div>
-</div>
-<div class="section" id="second-subtitle">
-    <h2>
-        Second subtitle
-    </h2>
-    <div class="section" id="third-subsubtitle">
-        <h3>
-            Third subsubtitle
-        </h3>
-        <p>Text again</p>
+    <div class="section" id="second-subtitle">
+        <h2>
+            Second subtitle
+        </h2>
+        <div class="section" id="third-subsubtitle">
+            <h3>
+                Third subsubtitle
+            </h3>
+            <p>Text again</p>
+        </div>
+        <div class="section" id="fourth-subsubtitle">
+            <h3>
+                Fourth subsubtitle
+            </h3>
+        </div>
     </div>
-    <div class="section" id="fourth-subsubtitle">
-        <h3>
-            Fourth subsubtitle
-        </h3>
+    <div class="section" id="em">
+        <h2>
+            em
+        </h2>
     </div>
-</div>
-<div class="section" id="em">
-    <h2>
-        em
-    </h2>
 </div>
 <div class="section" id="second-main-title">
     <h1>

--- a/tests/Functional/tests/titles/titles.tex
+++ b/tests/Functional/tests/titles/titles.tex
@@ -12,7 +12,6 @@ Some text
 
 
 
-
 \section{Second subtitle}
 
 \subsection{Third subsubtitle}
@@ -24,6 +23,7 @@ Text again
 
 
 \section{em}
+
 
 
 \chapter{Second Main Title}


### PR DESCRIPTION
I noticed a minor issue with the `section` tags. Take the following situation:

```rst
h1 Foo
=====

h2 Bar
------

h3 Baz
~~~~~

h2 Bazzles
-----------
```

The `h2 Bazzles` should still be a child inside the `h1 Foo` section. But the HTML markup closes and puts the `h2` into a sibling div of the `h1`.

This includes a failing test case to show the behavior - but I'm not sure where this is controlled in the code.

Cheers!