### PR TITLE
Improve missing reference error

### DIFF
--- a/lib/Environment.php
+++ b/lib/Environment.php
@@ -143,7 +143,7 @@ class Environment
     public function resolve(string $section, string $data) : ?ResolvedReference
     {
         if (! isset($this->references[$section])) {
-            throw new InvalidArgumentException(sprintf('Unknown reference section %s', $section));
+            throw new InvalidArgumentException($this->getMissingReferenceSectionError($section));
         }
 
         $reference = $this->references[$section];
@@ -200,7 +200,7 @@ class Environment
             return null;
         }
 
-        $this->errorManager->error('Unknown reference section ' . $section);
+        $this->errorManager->error($this->getMissingReferenceSectionError($section));
 
         return null;
     }
@@ -484,5 +484,14 @@ class Environment
         $text = strtolower($text);
 
         return $text;
+    }
+
+    private function getMissingReferenceSectionError(string $section): string
+    {
+        return sprintf(
+            'Unknown reference section "%s"%s',
+            $section,
+            $this->getCurrentFileName() ? sprintf(' in "%s" ', $this->getCurrentFileName()) : ''
+        );
     }
 }

--- a/lib/Environment.php
+++ b/lib/Environment.php
@@ -143,7 +143,9 @@ class Environment
     public function resolve(string $section, string $data) : ?ResolvedReference
     {
         if (! isset($this->references[$section])) {
-            throw new InvalidArgumentException($this->getMissingReferenceSectionError($section));
+            $this->addMissingReferenceSectionError($section);
+
+            return null;
         }
 
         $reference = $this->references[$section];
@@ -200,7 +202,7 @@ class Environment
             return null;
         }
 
-        $this->errorManager->error($this->getMissingReferenceSectionError($section));
+        $this->addMissingReferenceSectionError($section);
 
         return null;
     }
@@ -486,12 +488,12 @@ class Environment
         return $text;
     }
 
-    private function getMissingReferenceSectionError(string $section): string
+    private function addMissingReferenceSectionError(string $section) : void
     {
-        return sprintf(
+        $this->errorManager->error(sprintf(
             'Unknown reference section "%s"%s',
             $section,
-            $this->getCurrentFileName() ? sprintf(' in "%s" ', $this->getCurrentFileName()) : ''
-        );
+            $this->getCurrentFileName() !== '' ? sprintf(' in "%s" ', $this->getCurrentFileName()) : ''
+        ));
     }
 }

--- a/tests/EnvironmentTest.php
+++ b/tests/EnvironmentTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\Tests\RST;
 
+use InvalidArgumentException;
 use Doctrine\RST\Configuration;
 use Doctrine\RST\Environment;
 use PHPUnit\Framework\TestCase;
@@ -51,5 +52,32 @@ class EnvironmentTest extends TestCase
         self::assertSame($environment->canonicalUrl('test.rst'), 'subdir1/subdir2/test.rst');
         self::assertSame($environment->canonicalUrl('../index.rst'), 'subdir1/index.rst');
         self::assertSame($environment->canonicalUrl('../../index.rst'), 'index.rst');
+    }
+
+    /**
+     * @dataProvider getMissingSectionTests
+     */
+    public function testResolveForMissingSection(string $expectedMessage, ?string $currentFilename)
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage($expectedMessage);
+        $environment = new Environment(new Configuration());
+        if (null !== $currentFilename) {
+            $environment->setCurrentFileName($currentFilename);
+        }
+        $environment->resolve('doc', '/path/to/unknown/doc');
+    }
+
+    public function getMissingSectionTests()
+    {
+        yield 'no_current_filename' => [
+            'Unknown reference section "doc"',
+            null
+        ];
+
+        yield 'with_current_filename' => [
+            'Unknown reference section "doc" in "current_doc_filename"',
+            'current_doc_filename'
+        ];
     }
 }

--- a/tests/EnvironmentTest.php
+++ b/tests/EnvironmentTest.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace Doctrine\Tests\RST;
 
-use InvalidArgumentException;
 use Doctrine\RST\Configuration;
 use Doctrine\RST\Environment;
 use PHPUnit\Framework\TestCase;
+use Throwable;
 
 /**
  * Unit testing for RST
@@ -57,27 +57,30 @@ class EnvironmentTest extends TestCase
     /**
      * @dataProvider getMissingSectionTests
      */
-    public function testResolveForMissingSection(string $expectedMessage, ?string $currentFilename)
+    public function testResolveForMissingSection(string $expectedMessage, ?string $currentFilename) : void
     {
-        $this->expectException(InvalidArgumentException::class);
+        $this->expectException(Throwable::class);
         $this->expectExceptionMessage($expectedMessage);
         $environment = new Environment(new Configuration());
-        if (null !== $currentFilename) {
+        if ($currentFilename !== null) {
             $environment->setCurrentFileName($currentFilename);
         }
         $environment->resolve('doc', '/path/to/unknown/doc');
     }
 
-    public function getMissingSectionTests()
+    /**
+     * @return mixed[]
+     */
+    public function getMissingSectionTests() : iterable
     {
         yield 'no_current_filename' => [
             'Unknown reference section "doc"',
-            null
+            null,
         ];
 
         yield 'with_current_filename' => [
             'Unknown reference section "doc" in "current_doc_filename"',
-            'current_doc_filename'
+            'current_doc_filename',
         ];
     }
 }


### PR DESCRIPTION
Another error where, at the very least, I've added the current filename (if we have one) that's being parsed.

A few notes:

1) The message was duplicated... so that's handled
2) Eventually, we should also be adding the current line number of these errors - but I don't think that's really possible yet
3) The `getCurrentFileName()` returns the filename with the `.rst`... which makes it fine, but not perfect.