### PR TITLE
Adding support for references with ticks

### DIFF
--- a/lib/Parser/LineDataParser.php
+++ b/lib/Parser/LineDataParser.php
@@ -47,7 +47,13 @@ class LineDataParser
             return $this->createLink('_', $url, Link::TYPE_LINK);
         }
 
-        // Anchor link
+        // Anchor links - ".. _`anchor-link`:"
+        if (preg_match('/^\.\. _`(.+)`:$/mUsi', trim($line), $match) > 0) {
+            $anchor = $match[1];
+
+            return new Link($anchor, '#' . $anchor, Link::TYPE_ANCHOR);
+        }
+
         if (preg_match('/^\.\. _(.+):$/mUsi', trim($line), $match) > 0) {
             $anchor = $match[1];
 

--- a/tests/Builder/BuilderTest.php
+++ b/tests/Builder/BuilderTest.php
@@ -159,6 +159,9 @@ class BuilderTest extends BaseBuilderTest
 
         $contents = $this->getFileContents($this->targetFile('index.html'));
 
+        self::assertContains('Link to <a href="index.html#same_doc_reference">the same doc reference</a>', $contents);
+        self::assertContains('Link to <a href="index.html#same_doc_reference_ticks">the same doc reference with ticks</a>', $contents);
+
         self::assertContains('Link to <a href="subdir/test.html#subdirectory">Subdirectory</a>', $contents);
         self::assertContains('Link to <a href="subdir/test.html#subdirectory">Subdirectory Test</a>', $contents);
 

--- a/tests/Builder/input/index.rst
+++ b/tests/Builder/input/index.rst
@@ -19,6 +19,10 @@ Link to :ref:`the same doc reference <same_doc_reference>`
 
 .. _same_doc_reference:
 
+Link to :ref:`the same doc reference with ticks <same_doc_reference_ticks>`
+
+.. _`same_doc_reference_ticks`:
+
 Link to :ref:`Subdirectory <subdirectory>`
 
 Link to :ref:`Subdirectory Test <subdirectory>`


### PR DESCRIPTION
References are allowed to have extra "ticks" around them, which was already supported for normal links (see a few lines above in `LineDataParser`.