### PR TITLE
Fixing anonymous reference over-matching

### DIFF
--- a/lib/Parser/LineDataParser.php
+++ b/lib/Parser/LineDataParser.php
@@ -36,6 +36,7 @@ class LineDataParser
             return $this->createLink($match[1], $match[2], Link::TYPE_LINK);
         }
 
+        // anonymous links
         if (preg_match('/^\.\. _(.+): (.+)$/mUsi', $line, $match) > 0) {
             return $this->createLink($match[1], $match[2], Link::TYPE_LINK);
         }

--- a/tests/Functional/tests/anonymous/anonymous.html
+++ b/tests/Functional/tests/anonymous/anonymous.html
@@ -1,1 +1,1 @@
-<p>I love <a href="http://www.github.com/">GitHub</a> but I don't affect references to __CLASS__</p>
+<p>I love <a href="https://github.com/">GitHub</a>, <a href="https://gitlab.com/">GitLab</a> and <a href="https://facebook.com/">Facebook</a>. But I don't affect references to __CLASS__.</p>

--- a/tests/Functional/tests/anonymous/anonymous.html
+++ b/tests/Functional/tests/anonymous/anonymous.html
@@ -1,1 +1,1 @@
-<p>I love <a href="http://www.github.com/">GitHub</a></p>
+<p>I love <a href="http://www.github.com/">GitHub</a> but I don't affect references to __CLASS__</p>

--- a/tests/Functional/tests/anonymous/anonymous.rst
+++ b/tests/Functional/tests/anonymous/anonymous.rst
@@ -1,3 +1,5 @@
-I love GitHub__ but I don't affect references to __CLASS__
+I love GitHub__, GitLab__ and `Facebook`__. But I don't affect references to __CLASS__.
 
-.. __: http://www.github.com/
+.. __: https://github.com/
+.. __: https://gitlab.com/
+.. __: https://facebook.com/

--- a/tests/Functional/tests/anonymous/anonymous.rst
+++ b/tests/Functional/tests/anonymous/anonymous.rst
@@ -1,3 +1,3 @@
-I love GitHub__
+I love GitHub__ but I don't affect references to __CLASS__
 
 .. __: http://www.github.com/

--- a/tests/Functional/tests/anonymous/anonymous.tex
+++ b/tests/Functional/tests/anonymous/anonymous.tex
@@ -1,1 +1,1 @@
-I love \href{http://www.github.com/}{GitHub} but I don't affect references to __CLASS__
+I love \href{https://github.com/}{GitHub}, \href{https://gitlab.com/}{GitLab} and \href{https://facebook.com/}{Facebook}. But I don't affect references to __CLASS__.

--- a/tests/Functional/tests/anonymous/anonymous.tex
+++ b/tests/Functional/tests/anonymous/anonymous.tex
@@ -1,1 +1,1 @@
-I love \href{http://www.github.com/}{GitHub}
+I love \href{http://www.github.com/}{GitHub} but I don't affect references to __CLASS__


### PR DESCRIPTION
We have some `__CLASS__` in the symfony docs, and they're being interpreted as anonymous links. I double-checked in Sphinx: we ARE parsing them correctly in this lib currently (e.g. the test is 100% correct), but we are *overmatching* - Sphinx correctly does NOT see `__CLASS__` as an anonymous link.

But, I'll be honest - I'm not sure how they're doing this - they seem to be smart enough to notice that there is not also a starting `__` at the beginning. I even tested `I love __GitHub__` to see if that would STILL match the anonymous link (after all, it still ends with `__`) but in Sphinx - it fails.