### PR TITLE
failing test case for "raw urls"

### DIFF
--- a/tests/Parser/ParserTest.php
+++ b/tests/Parser/ParserTest.php
@@ -389,6 +389,16 @@ class ParserTest extends TestCase
     }
 
     /**
+     * Assert that a raw url is not transformed into an anchor node
+     */
+    public function testRawUrl() : void
+    {
+        $document = $this->parse('url-raw.rst');
+
+        self::assertNotContains('<a', $document->renderDocument());
+    }
+
+    /**
      * Helper function, parses a file and returns the document
      * produced by the parser
      */

--- a/tests/Parser/files/url-raw.rst
+++ b/tests/Parser/files/url-raw.rst
@@ -1,0 +1,2 @@
+
+http://doctrine-project.org/


### PR DESCRIPTION
Hi,
when the parser finds a trailing "raw url" in the rst files, it transforms it in an anchor node.

ex:
```rst
http://doctrine-project.org/
```

is tranformed to 
```html
<p><a href="http://doctrine-project.org/">http://doctrine-project.org/</a>
```

Problem is sometime in symfony doc, we use some urls that are not meant to be transformed.
Example:
`http://%env(HOST)%/project` that you can find here:
https://symfony.com/doc/current/configuration/external_parameters.html
(moreover it creates an anchor node in a code block, which seems pretty strange)

thanks :)