### PR TITLE
failing test case: directive nested in definition list

### DIFF
--- a/tests/Functional/tests/definition-list/definition-list.html
+++ b/tests/Functional/tests/definition-list/definition-list.html
@@ -73,3 +73,16 @@
         <dd>definition 1 definition 2 </dd>
     </dl>
 </div>
+<div class="section" id="directive-in-definition-list">
+    <h1>
+        Directive in definition list
+    </h1>
+    <dl>
+        <dt>term 1</dt>
+        <dd>
+            <div class="note">
+                <p>directive in definition list</p>
+            </div>
+        </dd>
+    </dl>
+</div>

--- a/tests/Functional/tests/definition-list/definition-list.rst
+++ b/tests/Functional/tests/definition-list/definition-list.rst
@@ -73,3 +73,11 @@ Paragraph 2
 term 2
     definition 1
     definition 2
+
+Directive in definition list
+============================
+
+term 1
+    .. note::
+
+        directive in definition list


### PR DESCRIPTION
Hi,

a directive nested inside a definition list is not interpreted, and outputs not transformed:

```rst
term 1
    .. note::

        directive in definition list
```

is converted to:
```html
     <dl>
         <dt>term 1</dt>
         <dd>
            <p class="first">.. note:: </p>
            <p class="last">directive in definition list </p>
         </dd>
     </dl>
     </dl>
```

whereas sphinx works great with such case: https://symfony.com/doc/current/configuration/external_parameters.html#environment-variable-processors

here is a failing test case.

thanks 