### PR TITLE
Fix PHP 7.3 regex compilation failures.

### DIFF
--- a/lib/Parser/DocumentParser.php
+++ b/lib/Parser/DocumentParser.php
@@ -563,7 +563,7 @@ class DocumentParser
             $message = sprintf(
                 'Unknown directive: "%s" %sfor line "%s"',
                 $parserDirective->getName(),
-                $this->environment->getCurrentFileName() ? sprintf('in "%s" ', $this->environment->getCurrentFileName()) : '',
+                $this->environment->getCurrentFileName() !== '' ? sprintf('in "%s" ', $this->environment->getCurrentFileName()) : '',
                 $line
             );
 

--- a/lib/Span/SpanProcessor.php
+++ b/lib/Span/SpanProcessor.php
@@ -209,7 +209,7 @@ class SpanProcessor
     {
         // Replace standalone hyperlinks using a modified version of @gruber's
         // "Liberal Regex Pattern for all URLs", https://gist.github.com/gruber/249502
-        $absoluteUriPattern = '#(?i)\b((?:[a-z][\w-+.]+:(?:/{1,3}|[a-z0-9%]))('
+        $absoluteUriPattern = '#(?i)\b((?:[a-z][\w\-+.]+:(?:/{1,3}|[a-z0-9%]))('
             . '?:[^\s()<>]+|\(([^\s()<>]+|(\([^\s()<>]+\)))*\))+(?:\(([^\s()<>'
             . ']+|(\([^\s()<>]+\)))*\)|[^\s\`!()\[\]{};:\'".,<>?«»“”‘’]))#';
 


### PR DESCRIPTION
Something changed in PHP 7.3 and this regex now fails due to an unescaped `-` https://github.com/doctrine/rst-parser/blob/master/lib/Span/SpanProcessor.php#L212

This is the error:

```
preg_replace_callback(): Compilation failed: invalid range in character class at offset 18
/home/travis/build/doctrine/rst-parser/lib/Span/SpanProcessor.php:232
```