### PR TITLE
Fix links to title which contains "&"

### DIFF
--- a/lib/Nodes/DocumentNode.php
+++ b/lib/Nodes/DocumentNode.php
@@ -139,7 +139,7 @@ class DocumentNode extends Node
             }
 
             $level       = $node->getLevel();
-            $text        = $node->getValue()->render();
+            $text        = $node->getValue()->getValue();
             $redirection = $node->getTarget();
             $value       = $redirection !== '' ? [$text, $redirection] : $text;
 

--- a/tests/Builder/BuilderTest.php
+++ b/tests/Builder/BuilderTest.php
@@ -299,6 +299,11 @@ class BuilderTest extends BaseBuilderTest
             '<p>see <a href="magic-link.html#test">test</a></p>',
             $contents
         );
+
+        self::assertContains(
+            '<p>see <a href="magic-link.html#title-with-ampersand">title with ampersand &amp;</a></p>',
+            $contents
+        );
     }
 
     public function testHeadings() : void

--- a/tests/Builder/input/another.rst
+++ b/tests/Builder/input/another.rst
@@ -12,6 +12,9 @@ See also
 test
 ----
 
+title with ampersand &
+----------------------
+
 This same title named test exists in other documents. Make sure the link below goes to the one
 in this doc and not the one in the other docs.
 
@@ -22,3 +25,5 @@ see `See also`_
 see `Another page`_
 
 see `test`_
+
+see `title with ampersand &`_


### PR DESCRIPTION
Hello,

titles are stored in metas using their rendered representation:
```php
// DocumentNode:getTitles()

/** @var TitleNode $node */
$text = $node->getValue()->render();
```
Then when a title contains a "&", the latter is stored like this: "&amp;"
This leads to an error, when a link is created on this on this title, we were looking for the occurence with "&".

It seems that titles does not be need to be rendered here, because this treatment is made in twig:
```twig
{# lib/Templates/default/html/header-title.html.twig #}
<h{{ titleNode.level }}>{{ titleNode.value.render()|raw }}</h{{ titleNode.level }}>
```

cheers.
