### PR TITLE
Exposing Metas and ParseQueue from Builder

### DIFF
--- a/lib/Event/PreBuildParseEvent.php
+++ b/lib/Event/PreBuildParseEvent.php
@@ -4,7 +4,23 @@ declare(strict_types=1);
 
 namespace Doctrine\RST\Event;
 
+use Doctrine\RST\Builder;
+
 final class PreBuildParseEvent extends BuildEvent
 {
     public const PRE_BUILD_PARSE = 'preBuildParse';
+
+    /** @var Builder\ParseQueue */
+    private $parseQueue;
+
+    public function __construct(Builder $builder, string $directory, string $targetDirectory, Builder\ParseQueue $parseQueue)
+    {
+        parent::__construct($builder, $directory, $targetDirectory);
+        $this->parseQueue = $parseQueue;
+    }
+
+    public function getParseQueue() : Builder\ParseQueue
+    {
+        return $this->parseQueue;
+    }
 }


### PR DESCRIPTION
In some last details, we've ran into 2 things that we need access to that we're continually working around:

1) `Metas` - we use these after the build is done to dump some of its data (and some data from the HTML files) into a JSON format that's read programmatically by something else later.

2) `ParseQueue` - this is useful *before* parsing happens, so we can accurately print a progress bar that knows how many files will *actually* be parsed (it may not be all RST files due to caching). Second, it's useful after the build is done so that we can do some post-processing... but can do it only on the files that were actually parsed (and can ignore doing that processing on files that weren't even updated).