### PR TITLE
using error manager for a malformed table

### DIFF
--- a/lib/Nodes/TableNode.php
+++ b/lib/Nodes/TableNode.php
@@ -6,7 +6,6 @@ namespace Doctrine\RST\Nodes;
 
 use Doctrine\RST\Parser;
 use Doctrine\RST\Parser\LineChecker;
-use RuntimeException;
 use function array_fill_keys;
 use function array_keys;
 use function array_map;
@@ -146,7 +145,14 @@ class TableNode extends Node
                 return implode(' | ', $item);
             }, $this->data);
 
-            throw new RuntimeException(sprintf("Malformed table:\n%s\n\nin file: \"%s\"", implode("\n", $data), $parser->getFilename()));
+            $parser->getEnvironment()
+                ->getErrorManager()
+                ->error(sprintf("Malformed table:\n%s\n\nin file: \"%s\"", implode("\n", $data), $parser->getFilename()));
+
+            // empty the table if it's malformed
+            $this->data = [];
+
+            return;
         }
 
         foreach ($this->data as &$row) {

--- a/tests/BaseBuilderTest.php
+++ b/tests/BaseBuilderTest.php
@@ -23,7 +23,12 @@ abstract class BaseBuilderTest extends TestCase
 
         $this->builder = new Builder();
         $this->builder->getConfiguration()->setUseCachedMetas(false);
+        $this->configureBuilder($this->builder);
         $this->builder->build($this->sourceFile(), $this->targetFile());
+    }
+
+    protected function configureBuilder(Builder $builder) : void
+    {
     }
 
     protected function sourceFile(string $file = '') : string

--- a/tests/BuilderWithErrors/BuilderWithErrors.php
+++ b/tests/BuilderWithErrors/BuilderWithErrors.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\RST\BuilderWithErrors;
+
+use Doctrine\RST\Builder;
+use Doctrine\Tests\RST\BaseBuilderTest;
+
+class BuilderWithErrors extends BaseBuilderTest
+{
+    protected function configureBuilder(Builder $builder) : void
+    {
+        $builder->getConfiguration()->abortOnError(false);
+    }
+
+    public function testMalformedTable() : void
+    {
+        $contents = $this->getFileContents($this->targetFile('index.html'));
+        self::assertContains('<table', $contents);
+        self::assertNotContains('<tr', $contents);
+    }
+
+    protected function getFixturesDirectory() : string
+    {
+        return 'BuilderWithErrors';
+    }
+}

--- a/tests/BuilderWithErrors/input/index.rst
+++ b/tests/BuilderWithErrors/input/index.rst
@@ -1,0 +1,13 @@
+Title
+=====
+
+Here is a malformed table.
+
+==========  ========================================  ==========================================
+Route path  If the requested URL is ``/foo``          If the requested URL is ``/foo/``
+----------  -----------------------------------  ------------------------------------------
+``/foo``    It matches (``200`` status response)      It makes a ``301`` redirect to ``/foo``
+``/foo/``   It makes a ``301`` redirect to ``/foo/``  It matches (``200`` status response)
+==========  ========================================  ==========================================
+
+And some text after!

--- a/tests/BuilderWithErrors/input/orphaned/file.rst
+++ b/tests/BuilderWithErrors/input/orphaned/file.rst
@@ -1,0 +1,3 @@
+This file should not be parsed
+==============================
+

--- a/tests/BuilderWithErrors/input/subdir/toctree.rst
+++ b/tests/BuilderWithErrors/input/subdir/toctree.rst
@@ -1,0 +1,13 @@
+Toctree
+=======
+
+.. toctree::
+    :glob:
+
+    *
+
+.. toctree::
+    :glob:
+
+    /subdir/*
+

--- a/tests/Functional/tests/simple-table-error/simple-table-error.html
+++ b/tests/Functional/tests/simple-table-error/simple-table-error.html
@@ -1,4 +1,4 @@
-Exception: RuntimeException
+Exception: Exception
 Malformed table:
 
 First col | Second col | Third col


### PR DESCRIPTION
We're trying to make our failures a bit softer.

This is consistent with Sphinx - it outputs a warning during the parse process, but it's not fatal (unless you opt into warnings being fatal, which is an option).

<img width="1280" alt="screen shot 2019-03-08 at 12 03 05 pm" src="https://user-images.githubusercontent.com/121003/54043299-3ca92d80-419a-11e9-85e8-04d4fe4cf0c9.png">

When this fails, the output gets a `<table><tbody>`, but no rows. In Sphinx, the entire table is gone - but I think this is "close enough" - we don't need to optimize for a failed build situation.