### PR TITLE
Fixing invalid meta removal

### DIFF
--- a/lib/Environment.php
+++ b/lib/Environment.php
@@ -157,8 +157,10 @@ class Environment
 
             if ($this->getMetaEntry() !== null) {
                 $this->getMetaEntry()->removeDependency(
-                    // use the unique, unresolved name
-                    $this->unresolvedDependencies[$data] ?? $data
+                    // for references, use the original, unresolved name
+                    // for doc links, use the canonical URL
+                    // see addDependency()
+                    $this->unresolvedDependencies[$data] ?? (string) $this->canonicalUrl($data)
                 );
             }
 

--- a/lib/Meta/MetaEntry.php
+++ b/lib/Meta/MetaEntry.php
@@ -153,8 +153,9 @@ class MetaEntry
     {
         $key = array_search($dependency, $this->depends, true);
 
+        // it's possible a dependency is removed multiple times
         if ($key === false) {
-            throw new LogicException(sprintf('Could not find dependency "%s" in MetaEntry for "%s"', $dependency, $this->file));
+            return;
         }
 
         unset($this->depends[$key]);

--- a/tests/BuilderInvalidLinks/BuilderInvalidLinksTest.php
+++ b/tests/BuilderInvalidLinks/BuilderInvalidLinksTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\RST\BuilderInvalidLinks;
+
+use Doctrine\RST\Builder;
+use Doctrine\RST\Meta\MetaEntry;
+use Doctrine\Tests\RST\BaseBuilderTest;
+use function file_get_contents;
+use function unserialize;
+
+class BuilderInvalidLinksTest extends BaseBuilderTest
+{
+    protected function configureBuilder(Builder $builder) : void
+    {
+        $builder->getConfiguration()->abortOnError(false);
+    }
+
+    public function testInvalidLinksRemovedFromMetas() : void
+    {
+        $cachedContents = (string) file_get_contents($this->targetFile('metas.php'));
+        /** @var MetaEntry[] $metaEntries */
+        $metaEntries = unserialize($cachedContents);
+        // will only depend on "good" because other links are invalid
+        self::assertCount(1, $metaEntries['subdir/foo']->getDepends());
+    }
+
+    protected function getFixturesDirectory() : string
+    {
+        return 'BuilderInvalidLinks';
+    }
+}

--- a/tests/BuilderInvalidLinks/input/good.rst
+++ b/tests/BuilderInvalidLinks/input/good.rst
@@ -1,0 +1,4 @@
+Good File
+=========
+
+Nothing interesting...

--- a/tests/BuilderInvalidLinks/input/index.rst
+++ b/tests/BuilderInvalidLinks/input/index.rst
@@ -1,0 +1,6 @@
+Testing Invalid Doc Links
+=========================
+
+.. toctree::
+    /subdir/foo
+    good

--- a/tests/BuilderInvalidLinks/input/subdir/foo.rst
+++ b/tests/BuilderInvalidLinks/input/subdir/foo.rst
@@ -1,0 +1,6 @@
+File with Bad Links
+===================
+
+* :doc:`Index with extra slash <..//index>`
+* :doc:`Another one <..//index>`
+* :doc:`Good link <../good>`


### PR DESCRIPTION
> The URL for :doc: links needs to be canonical to match when the dep is added. See `addDependency()` for matching logic.

> Also, if there are multiple invalid links, the dependency could be removed
multiple times - so we can't unset it once then check in removeDependency()
if it exists, because it would fail the second time.

Test is WIP. The bug basically only affects the cached meta files, which are used only for rebuilding faster with cache.