### PR TITLE
Also clearing headers so TableNodeRenderer doesn't see a mismatch

### DIFF
--- a/lib/Nodes/TableNode.php
+++ b/lib/Nodes/TableNode.php
@@ -149,7 +149,8 @@ class TableNode extends Node
                 ->getErrorManager()
                 ->error(sprintf("%s\nin file %s\n\n%s", $this->errors[0], $parser->getFilename(), $tableAsString));
 
-            $this->data = [];
+            $this->data    = [];
+            $this->headers = [];
 
             return;
         }


### PR DESCRIPTION
When there is an invalid table structure, we clear the data so that we don't try to render a messed up table. We also need to clear `$this->headers` so that `TableNodeRenderer` doesn't see a mismatch:

> Hey! You said row 2 is a header... but I don't see a row 2!
