### PR TITLE
Implement 'initialHeaderLevel' config setting

### DIFF
--- a/docs/en/configuration.rst
+++ b/docs/en/configuration.rst
@@ -80,3 +80,14 @@ indented consistently, you can enable this feature using the ``setIndentHTML(boo
     This feature only works when rendering full HTML documents using the
     ``Doctrine\RST\Nodes\DocumentNode::renderDocument()`` method. If you render
     an individual node with the ``render()`` method, the outputted HTML will not be indented.
+
+Initial Header Level
+--------------------
+
+Normally, document headings start at ``h1``. You can override this by setting the ``initialHeaderLevel`` configuration
+option:
+
+.. code-block:: php
+
+    // Set the top-most document header to <h2>
+    $configuration->setInitialHeaderLevel(2);

--- a/lib/Configuration.php
+++ b/lib/Configuration.php
@@ -52,6 +52,9 @@ class Configuration
     /** @var bool */
     private $indentHTML = false;
 
+    /** @var int */
+    private $initialHeaderLevel = 1;
+
     /** @var bool */
     private $useCachedMetas = true;
 
@@ -216,6 +219,16 @@ class Configuration
     public function getIndentHTML() : bool
     {
         return $this->indentHTML;
+    }
+
+    public function setInitialHeaderLevel(int $initialHeaderLevel) : void
+    {
+        $this->initialHeaderLevel = $initialHeaderLevel;
+    }
+
+    public function getInitialHeaderLevel() : int
+    {
+        return $this->initialHeaderLevel;
     }
 
     public function setUseCachedMetas(bool $useCachedMetas) : void

--- a/lib/Parser/DocumentParser.php
+++ b/lib/Parser/DocumentParser.php
@@ -414,6 +414,7 @@ class DocumentParser
                     $data = $this->buffer->getLinesString();
 
                     $level = $this->environment->getLevel((string) $this->specialLetter);
+                    $level = $this->environment->getConfiguration()->getInitialHeaderLevel() + $level - 1;
 
                     $token = $this->environment->createTitle($level);
 

--- a/tests/ConfigurationTest.php
+++ b/tests/ConfigurationTest.php
@@ -70,7 +70,7 @@ class ConfigurationTest extends TestCase
         self::assertTrue($this->configuration->getIgnoreInvalidReferences());
     }
 
-    public function testInitialHeaderLevel(): void
+    public function testInitialHeaderLevel() : void
     {
         self::assertSame(1, $this->configuration->getInitialHeaderLevel());
 

--- a/tests/ConfigurationTest.php
+++ b/tests/ConfigurationTest.php
@@ -70,6 +70,15 @@ class ConfigurationTest extends TestCase
         self::assertTrue($this->configuration->getIgnoreInvalidReferences());
     }
 
+    public function testInitialHeaderLevel(): void
+    {
+        self::assertSame(1, $this->configuration->getInitialHeaderLevel());
+
+        $this->configuration->setInitialHeaderLevel(2);
+
+        self::assertSame(2, $this->configuration->getInitialHeaderLevel());
+    }
+
     protected function setUp() : void
     {
         $this->configuration = new Configuration();

--- a/tests/Parser/ParserTest.php
+++ b/tests/Parser/ParserTest.php
@@ -31,13 +31,15 @@ class ParserTest extends TestCase
     /** @var Parser $parser */
     protected $parser;
 
-    protected function setUp()
+    protected function setUp() : void
     {
         parent::setUp();
 
         $directory = __DIR__ . '/files/';
-        $parser = new Parser();
+        $parser    = new Parser();
+
         $parser->getEnvironment()->setCurrentDirectory($directory);
+
         $this->parser = $parser;
     }
 
@@ -422,7 +424,7 @@ class ParserTest extends TestCase
     private function parse(string $file) : DocumentNode
     {
         $directory = $this->parser->getEnvironment()->getCurrentDirectory();
-        $data = file_get_contents($directory . $file);
+        $data      = file_get_contents($directory . $file);
 
         if ($data === false) {
             throw new Exception('Could not open file.');


### PR DESCRIPTION
Implement support for a new 'initial header level' setting, which allows a user to control the 'level' at which document headings should start (`h1`, `h2`, etc.) Defaults to `1`.

The config setting is present in the docutils library, and is discussed briefly in [this StackOverflow comment](https://stackoverflow.com/a/33422946).

A common use-case for this enhancement is content-management systems which use separate fields for the page title (`h1`), and an RST-formatted body.