### PR TITLE
using file mtime instead of ctime for caching

### DIFF
--- a/lib/Builder/ParseQueueProcessor.php
+++ b/lib/Builder/ParseQueueProcessor.php
@@ -9,7 +9,7 @@ use Doctrine\RST\Kernel;
 use Doctrine\RST\Meta\Metas;
 use Doctrine\RST\Nodes\DocumentNode;
 use Doctrine\RST\Parser;
-use function filectime;
+use function filemtime;
 
 class ParseQueueProcessor
 {
@@ -79,7 +79,7 @@ class ParseQueueProcessor
             (string) $document->getTitle(),
             $document->getTitles(),
             $document->getTocs(),
-            (int) filectime($fileAbsolutePath),
+            (int) filemtime($fileAbsolutePath),
             $environment->getDependencies(),
             $environment->getLinks()
         );

--- a/lib/Builder/Scanner.php
+++ b/lib/Builder/Scanner.php
@@ -133,7 +133,7 @@ class Scanner
         $entry            = $this->metas->get($documentFilename);
 
         // File is new or changed
-        return $entry === null || $entry->getCtime() < $file->getCTime();
+        return $entry === null || $entry->getMtime() < $file->getMTime();
     }
 
     /**

--- a/lib/Meta/MetaEntry.php
+++ b/lib/Meta/MetaEntry.php
@@ -31,7 +31,7 @@ class MetaEntry
     private $tocs;
 
     /** @var int */
-    private $ctime;
+    private $mtime;
 
     /** @var string[] */
     private $depends;
@@ -59,7 +59,7 @@ class MetaEntry
         array $tocs,
         array $depends,
         array $links,
-        int $ctime
+        int $mtime
     ) {
         $this->file    = $file;
         $this->url     = $url;
@@ -68,7 +68,7 @@ class MetaEntry
         $this->tocs    = $tocs;
         $this->depends = $depends;
         $this->links   = $links;
-        $this->ctime   = $ctime;
+        $this->mtime   = $mtime;
     }
 
     public function getFile() : string
@@ -168,9 +168,9 @@ class MetaEntry
         return $this->links;
     }
 
-    public function getCtime() : int
+    public function getMtime() : int
     {
-        return $this->ctime;
+        return $this->mtime;
     }
 
     public function setParent(string $parent) : void

--- a/lib/Meta/Metas.php
+++ b/lib/Meta/Metas.php
@@ -54,7 +54,7 @@ class Metas
         string $title,
         array $titles,
         array $tocs,
-        int $ctime,
+        int $mtime,
         array $depends,
         array $links
     ) : void {
@@ -78,7 +78,7 @@ class Metas
             $tocs,
             $depends,
             $links,
-            $ctime
+            $mtime
         );
 
         if (! isset($this->parents[$file])) {

--- a/tests/Builder/ScannerTest.php
+++ b/tests/Builder/ScannerTest.php
@@ -59,9 +59,9 @@ class ScannerTest extends TestCase
         $file1MetaMock = $this->createMetaEntryMock('file1');
 
         // file1.rst was modified 50 seconds ago
-        $file1InfoMock->method('getCTime')->willReturn(time() - 50);
+        $file1InfoMock->method('getMTime')->willReturn(time() - 50);
         // but file1 MetaEntry was modified 100 seconds ago (is out of date)
-        $file1MetaMock->method('getCTime')->willReturn(time() - 100);
+        $file1MetaMock->method('getMTime')->willReturn(time() - 100);
         // should never be called because the meta is definitely not fresh
         $file1MetaMock->expects(self::never())->method('getDepends');
 
@@ -70,9 +70,9 @@ class ScannerTest extends TestCase
 
         // file2.rst was modified 50 seconds ago
         $lastModifiedTime = time() - 50;
-        $file2InfoMock->method('getCTime')->willReturn($lastModifiedTime);
+        $file2InfoMock->method('getMTime')->willReturn($lastModifiedTime);
         // and file2 MetaEntry was also 50 seconds ago, fresh
-        $file2MetaMock->method('getCTime')->willReturn($lastModifiedTime);
+        $file2MetaMock->method('getMTime')->willReturn($lastModifiedTime);
         // ignore dependencies for this test
         $file2MetaMock->expects(self::once())
             ->method('getDepends')
@@ -107,50 +107,50 @@ class ScannerTest extends TestCase
          *      * file6
          */
 
-        $metaCTime = time() - 50;
+        $metaMTime = time() - 50;
 
         $file1InfoMock = $this->addFileMockToFinder('file1.rst');
-        $file1InfoMock->method('getCTime')->willReturn($metaCTime);
+        $file1InfoMock->method('getMTime')->willReturn($metaMTime);
         $file1MetaMock = $this->createMetaEntryMock('file1');
         $file1MetaMock->method('getDepends')
             ->willReturn(['file2']);
-        $file1MetaMock->method('getCTime')->willReturn($metaCTime);
+        $file1MetaMock->method('getMTime')->willReturn($metaMTime);
 
         $file2InfoMock = $this->addFileMockToFinder('file2.rst');
-        $file2InfoMock->method('getCTime')->willReturn($metaCTime);
+        $file2InfoMock->method('getMTime')->willReturn($metaMTime);
         $file2MetaMock = $this->createMetaEntryMock('file2');
         $file2MetaMock->method('getDepends')
             ->willReturn(['file2', 'file3']);
-        $file2MetaMock->method('getCTime')->willReturn($metaCTime);
+        $file2MetaMock->method('getMTime')->willReturn($metaMTime);
 
         $file3InfoMock = $this->addFileMockToFinder('file3.rst');
-        $file3InfoMock->method('getCTime')->willReturn($metaCTime);
+        $file3InfoMock->method('getMTime')->willReturn($metaMTime);
         $file3MetaMock = $this->createMetaEntryMock('file3');
         $file3MetaMock->method('getDepends')
             ->willReturn(['file4', 'file5', 'file3', 'file2']);
-        $file3MetaMock->method('getCTime')->willReturn($metaCTime);
+        $file3MetaMock->method('getMTime')->willReturn($metaMTime);
 
         $file4InfoMock = $this->addFileMockToFinder('file4.rst');
-        $file4InfoMock->method('getCTime')->willReturn($metaCTime);
+        $file4InfoMock->method('getMTime')->willReturn($metaMTime);
         $file4MetaMock = $this->createMetaEntryMock('file4');
         $file4MetaMock->method('getDepends')
             ->willReturn([]);
-        $file4MetaMock->method('getCTime')->willReturn($metaCTime);
+        $file4MetaMock->method('getMTime')->willReturn($metaMTime);
 
         $file5InfoMock = $this->addFileMockToFinder('file5.rst');
         // THIS file is the one file that's modified
-        $file5InfoMock->method('getCTime')->willReturn(time() - 10);
+        $file5InfoMock->method('getMTime')->willReturn(time() - 10);
         $file5MetaMock = $this->createMetaEntryMock('file5');
         $file5MetaMock->method('getDepends')
             ->willReturn(['file3', 'file6']);
-        $file5MetaMock->method('getCTime')->willReturn($metaCTime);
+        $file5MetaMock->method('getMTime')->willReturn($metaMTime);
 
         $file6InfoMock = $this->addFileMockToFinder('file6.rst');
-        $file6InfoMock->method('getCTime')->willReturn($metaCTime);
+        $file6InfoMock->method('getMTime')->willReturn($metaMTime);
         $file6MetaMock = $this->createMetaEntryMock('file6');
         $file6MetaMock->method('getDepends')
             ->willReturn(['file4']);
-        $file6MetaMock->method('getCTime')->willReturn($metaCTime);
+        $file6MetaMock->method('getMTime')->willReturn($metaMTime);
 
         $parseQueue = $this->scanner->scan();
         self::assertSame([
@@ -170,14 +170,14 @@ class ScannerTest extends TestCase
          * Result is that file 1 DOES need to be parsed
          */
 
-        $metaCTime = time() - 50;
+        $metaMTime = time() - 50;
 
         $file1InfoMock = $this->addFileMockToFinder('file1.rst');
-        $file1InfoMock->method('getCTime')->willReturn($metaCTime);
+        $file1InfoMock->method('getMTime')->willReturn($metaMTime);
         $file1MetaMock = $this->createMetaEntryMock('file1');
         $file1MetaMock->method('getDepends')
             ->willReturn(['file2']);
-        $file1MetaMock->method('getCTime')->willReturn($metaCTime);
+        $file1MetaMock->method('getMTime')->willReturn($metaMTime);
 
         // no file info made for file2
 


### PR DESCRIPTION
Fixes a bug if you, for example, rsync from one directory to another then build - the ctime might make those files look modified. We had this exact issue (we rsync from one dir to another before building): with ctime, all the source files looked modified *every* time.