### PR TITLE
Fixing theme bug where dir must exist in core + expanded "default" fallback

### DIFF
--- a/docs/en/themes.rst
+++ b/docs/en/themes.rst
@@ -30,3 +30,7 @@ named ``layout.html.twig`` and you can customize the layout that wraps all gener
             {% block body '' %}
         </body>
     </html>
+
+Even with a theme, the rendering engine will continue to
+use a ``default`` directory (e.g. ``/path/to/custom/templates/default/html``
+as a fallback for any templates (see :doc:`/customizing-rendering`).

--- a/lib/Templates/TwigEnvironmentFactory.php
+++ b/lib/Templates/TwigEnvironmentFactory.php
@@ -7,13 +7,14 @@ namespace Doctrine\RST\Templates;
 use Doctrine\RST\Configuration;
 use Twig\Environment as TwigEnvironment;
 use Twig\Loader\FilesystemLoader;
+use function file_exists;
 use function sprintf;
 
 class TwigEnvironmentFactory
 {
     public static function createTwigEnvironment(Configuration $configuration) : TwigEnvironment
     {
-        $loader = new FilesystemLoader(self::getTemplatesDirs($configuration));
+        $loader = new FilesystemLoader(self::getTemplateDirs($configuration));
 
         return new TwigEnvironment($loader, [
             'strict_variables' => true,
@@ -22,37 +23,37 @@ class TwigEnvironmentFactory
         ]);
     }
 
-    private static function getThemeDir(Configuration $configuration, string $templatesDir, ?string $theme = null) : string
-    {
-        $theme         = $theme ?? $configuration->getTheme();
-        $fileExtension = $configuration->getFileExtension();
-
-        return $templatesDir . '/' . $theme . '/' . $fileExtension;
-    }
-
     /**
      * @return string[]
      */
-    private static function getTemplatesDirs(Configuration $configuration) : array
+    private static function getTemplateDirs(Configuration $configuration) : array
     {
-        $themeDirs = [];
+        $themeDirs     = [];
+        $fileExtension = $configuration->getFileExtension();
 
-        // check custom template directories first
-        $customTemplateDirs = $configuration->getCustomTemplateDirs();
+        $templateDirectories = $configuration->getCustomTemplateDirs();
+        // add the fallback directory
+        $templateDirectories[] = __DIR__;
 
-        if ($customTemplateDirs !== []) {
-            foreach ($customTemplateDirs as $customTemplateDir) {
-                $themeDirs[] = self::getThemeDir($configuration, $customTemplateDir);
+        foreach ($templateDirectories as $templateDir) {
+            $themePath = $templateDir . '/' . $configuration->getTheme() . '/' . $fileExtension;
+            if (! file_exists($themePath)) {
+                continue;
             }
+
+            $themeDirs[] = $themePath;
         }
 
-        // fallback to core templates for the configured theme
-        $themeDirs[] = self::getThemeDir($configuration, __DIR__);
-
-        // fallback to core templates for the default theme
-        // if the configured theme is not the default
+        // look for the fallback "default" in all directories
         if ($configuration->getTheme() !== Configuration::THEME_DEFAULT) {
-            $themeDirs[] = self::getThemeDir($configuration, __DIR__, Configuration::THEME_DEFAULT);
+            foreach ($templateDirectories as $templateDir) {
+                $themePath = $templateDir . '/' . Configuration::THEME_DEFAULT . '/' . $fileExtension;
+                if (! file_exists($themePath)) {
+                    continue;
+                }
+
+                $themeDirs[] = $themePath;
+            }
         }
 
         return $themeDirs;

--- a/tests/Templates/TwigEnvironmentFactoryTest.php
+++ b/tests/Templates/TwigEnvironmentFactoryTest.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\RST\Templates;
+
+use Doctrine\RST\Configuration;
+use Doctrine\RST\Templates\TwigEnvironmentFactory;
+use Exception;
+use PHPUnit\Framework\TestCase;
+use Symfony\Component\Filesystem\Filesystem;
+use Twig\Environment;
+use Twig\Loader\FilesystemLoader;
+use function realpath;
+use function sys_get_temp_dir;
+
+class TwigEnvironmentFactoryTest extends TestCase
+{
+    /** @var string */
+    private $tmpPath;
+    /** @var Filesystem */
+    private $filesystem;
+
+    public function testTemplateDirectoriesNothingCustom() : void
+    {
+        $configuration = new Configuration();
+        $configuration->setFileExtension('html');
+
+        // no theme, no custom dirs
+        self::assertLoaderPaths(
+            [(string) realpath(__DIR__ . '/../../lib/Templates/default/html')],
+            TwigEnvironmentFactory::createTwigEnvironment($configuration)
+        );
+    }
+
+    public function testTemplateDirectoriesThemeAndDirectories() : void
+    {
+        $configuration = new Configuration();
+        $configuration->setFileExtension('html');
+        $configuration->setTheme('cool_theme');
+
+        $dir1           = $this->tmpPath . '/dir1';
+        $dir2           = $this->tmpPath . '/dir2';
+        $nonExistentDir = $this->tmpPath . '/dir3';
+
+        // dir1 has all directories
+        $this->filesystem->mkdir($dir1);
+        $this->filesystem->mkdir($dir1 . '/default/html');
+        $this->filesystem->mkdir($dir1 . '/cool_theme/html');
+
+        // dir2 has just the theme
+        $this->filesystem->mkdir($dir2);
+        $this->filesystem->mkdir($dir2 . '/cool_theme/html');
+
+        $configuration->setCustomTemplateDirs([$dir1, $dir2, $nonExistentDir]);
+
+        // no theme, no custom dirs
+        self::assertLoaderPaths(
+            [
+                $dir1 . '/cool_theme/html',
+                $dir2 . '/cool_theme/html',
+                $dir1 . '/default/html',
+                (string) realpath(__DIR__ . '/../../lib/Templates/default/html'),
+            ],
+            TwigEnvironmentFactory::createTwigEnvironment($configuration)
+        );
+    }
+
+    /**
+     * @param string[] $expectedPaths
+     */
+    private static function assertLoaderPaths(array $expectedPaths, Environment $twig) : void
+    {
+        $loader = $twig->getLoader();
+        if (! $loader instanceof FilesystemLoader) {
+            throw new Exception('Wrong loader instance');
+        }
+
+        self::assertSame($expectedPaths, $loader->getPaths());
+    }
+
+    protected function setUp() : void
+    {
+        $this->tmpPath    = sys_get_temp_dir() . '/_rst_twig_tests';
+        $this->filesystem = new Filesystem();
+    }
+
+    protected function tearDown() : void
+    {
+        $this->filesystem->remove($this->tmpPath);
+    }
+}


### PR DESCRIPTION
Hiya!

I noticed two issues with the theming system:

1) If you use `$configuration->setTheme('my_theme');`, Twig would ALWAYS try to look
for a `lib/Templates/my_theme` directory (*inside* rst-parser itself), which would cause an exception. Setting themes was unusable.

2) There are two reasons to put "override" templates inside a library that uses `rst-parser`: 
A) to override individual pieces (e.g. `paragraph.html.twig`)
B) to override `layout.html.twig` for themeing

Previously, if you had 2 themes (`theme_foo` and `theme_bar`), each with their own `layout.html.twig` file, there was no place to put the overrides for part (A): the system would ONLY look inside the active theme directory for ALL overrides (so `paragraph.html.twig` would need to live in both directories, so that it was found when you switched).

There was already a "fallback" concept: look inside the user's "theme" directory, then fallback to the `default` directory in core. I expanded that to *always* look for the theme directory first, but then look for a directory called `default` in *all* template directories. This allows you to put all your "component" overrides in a `default` directory, then ONLY your `layout.html.twig` in the theme directory (though you could still override "components" there if you need to).

Test included and is BC... because themes weren't working properly yet :).

Cheers!