### PR TITLE
Allow library to be included with Symfony 5 projects

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     ],
     "require": {
         "php": "^7.1",
-        "symfony/filesystem": "^4.1",
+        "symfony/filesystem": "^4.1|^5.0",
         "twig/twig": "^2.9.0",
         "doctrine/event-manager": "^1.0"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f32d3cfc9c5945c035317bff7e2ddb87",
+    "content-hash": "7d34c4ab1ff2029b284199517884572c",
     "packages": [
         {
             "name": "doctrine/event-manager",


### PR DESCRIPTION
The dependency on symfony/filesystem 4 makes it hard to include this
project in a Symfony 5 based project. As far as my tests have
determined, symfony/filesystem did not break BC between 4 and 5. As such
I have updated the version constraint to allow for both 4 and 5.