### PR TITLE
Allow parse and transform to be ran independently

### DIFF
--- a/tests/Builder/BuilderTest.php
+++ b/tests/Builder/BuilderTest.php
@@ -7,6 +7,7 @@ namespace Doctrine\Tests\RST\Builder;
 use Doctrine\RST\Builder;
 use Doctrine\RST\Meta\MetaEntry;
 use Doctrine\Tests\RST\BaseBuilderTest;
+use InvalidArgumentException;
 
 use function array_unique;
 use function array_values;
@@ -337,6 +338,14 @@ class BuilderTest extends BaseBuilderTest
             '<a href="subdir/test.html#em">em</a>',
             $contents
         );
+    }
+
+    public function testItThrowsWhenIndexFileCannotBeFound(): void
+    {
+        $builder = new Builder();
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Could not find index file "index.rst" in "/tmp"');
+        $builder->parse('/tmp', '/tmp/test');
     }
 
     protected function getFixturesDirectory(): string


### PR DESCRIPTION
For phpDocumentor we want to be able to build a TOC for the API
documentation and the output of one or more runs of this RST parser and
inject that into the Twig templates.

In the existing setup, this causes a chicken and egg problem since the
TOC is only available after parsing, but we want to add more to the TOC
based on the output of other modules.

The solution to this scenario is to enable executing the parse and
render phase individually. This will allow us to gather the TOC earlier
in the application, combine it with other TOC elements, and then later
render the output using this updated TOC.