### PR TITLE
Fix installation instruction

### DIFF
--- a/docs/en/index.rst
+++ b/docs/en/index.rst
@@ -11,7 +11,7 @@ You can install the Doctrine RST Parser with composer:
 
 .. code-block:: console
 
-    $ composer install doctrine/rst-parser
+    $ composer require doctrine/rst-parser
 
 Basic Usage
 -----------


### PR DESCRIPTION
Previous instruction results in the following error:
```
$ composer install doctrine/rst-parser

Invalid argument doctrine/rst-parser. Use "composer require doctrine/rst-parser" instead to add packages to your composer.json.
```