### PR TITLE
Fix link with a parenthesis before

### DIFF
--- a/lib/Span/SpanProcessor.php
+++ b/lib/Span/SpanProcessor.php
@@ -202,14 +202,14 @@ class SpanProcessor
 
         // Replacing anonymous links
         $span = (string) preg_replace_callback(
-            '/(^|[ ])(([a-z0-9_-]+)|(`(.+)`))__([^a-z0-9]{1}|$)/mUsi',
+            '/(^|[ \(])(([a-z0-9_-]+)|(`(.+)`))__([^a-z0-9]{1}|$)/mUsi',
             $linkCallback,
             $span
         );
 
         // Replacing links
         $span = (string) preg_replace_callback(
-            '/(^|[ ])(([a-z0-9_-]+)|(`(.+)`))_([^a-z0-9]{1}|$)/mUsi',
+            '/(^|[ \(])(([a-z0-9_-]+)|(`(.+)`))_([^a-z0-9]{1}|$)/mUsi',
             $linkCallback,
             $span
         );

--- a/tests/LinkParserTest.php
+++ b/tests/LinkParserTest.php
@@ -58,6 +58,22 @@ EOF;
         self::assertContains('<p>Does Not Exist2</p>', $result);
     }
 
+    public function testLinkWithParenthesis() : void
+    {
+        $rst = <<<EOF
+Example_, `Example Web Site`_, Example (`Web Site`_), and Example (Link_)
+
+.. _Example: http://www.example.com/
+.. _`Example Web Site`: http://www.example.com/
+.. _`Web Site`: http://www.example.com/
+.. _Link: http://www.example.com/
+EOF;
+
+        $result = $this->parser->parse($rst)->render();
+
+        self::assertSame('<p><a href="http://www.example.com/">Example</a>, <a href="http://www.example.com/">Example Web Site</a>, Example (<a href="http://www.example.com/">Web Site</a>), and Example (<a href="http://www.example.com/">Link</a>)</p>', trim($result));
+    }
+
     protected function setUp() : void
     {
         $this->configuration = new Configuration();


### PR DESCRIPTION
Links like
```rst
Example (`Web Site`_), and Example (Link_)
```
were not rendered.