### PR TITLE
Add options to CodeNode

### DIFF
--- a/lib/Directives/CodeBlock.php
+++ b/lib/Directives/CodeBlock.php
@@ -44,6 +44,7 @@ class CodeBlock extends Directive
 
         if ($node instanceof CodeNode) {
             $node->setLanguage(trim($data));
+            $node->setOptions($options);
         }
 
         if ($variable !== '') {

--- a/lib/Nodes/CodeNode.php
+++ b/lib/Nodes/CodeNode.php
@@ -15,6 +15,9 @@ class CodeNode extends Node
     /** @var string|null */
     protected $language = null;
 
+    /** @var string[] */
+    private $options;
+
     /**
      * @param string[] $lines
      */
@@ -46,5 +49,21 @@ class CodeNode extends Node
     public function isRaw(): bool
     {
         return $this->raw;
+    }
+
+    /**
+     * @param string[] $options
+     */
+    public function setOptions(array $options = []): void
+    {
+        $this->options = $options;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getOptions(): array
+    {
+        return $this->options;
     }
 }

--- a/tests/Parser/ParserTest.php
+++ b/tests/Parser/ParserTest.php
@@ -72,6 +72,24 @@ class ParserTest extends TestCase
     }
 
     /**
+     * Testing that code node options are parsed
+     */
+    public function testCodeNodeWithOptions(): void
+    {
+        $document = $this->parse('code-block-with-options.rst');
+
+        $nodes = $document->getNodes(static function (Node $node): bool {
+            return $node instanceof CodeNode;
+        });
+
+        self::assertSame(1, count($nodes));
+        $codeNode = $nodes[0];
+        assert($codeNode instanceof CodeNode);
+        self::assertSame("A\nB\nC", trim($codeNode->getValueString()));
+        self::assertSame(['name' => 'My Very Best Code'], $codeNode->getOptions());
+    }
+
+    /**
      * Testing paragraph nodes
      */
     public function testParagraphNode(): void

--- a/tests/Parser/files/code-block-with-options.rst
+++ b/tests/Parser/files/code-block-with-options.rst
@@ -1,0 +1,7 @@
+
+.. code-block::
+    :name: My Very Best Code
+
+    A
+    B
+    C


### PR DESCRIPTION
This should unlock features similar to the one described at
https://www.sphinx-doc.org/en/1.5/markup/code.html
Options can now be defined in code nodes, and are then available in the
template.

Closes #120 