### PR TITLE
Fixing a bug with title links and ticks

### DIFF
--- a/tests/Builder/BuilderTest.php
+++ b/tests/Builder/BuilderTest.php
@@ -304,6 +304,11 @@ class BuilderTest extends BaseBuilderTest
             '<p>see <a href="magic-link.html#title-with-ampersand">title with ampersand &amp;</a></p>',
             $contents
         );
+
+        self::assertContains(
+            '<p>see <a href="magic-link.html#a-title-with-ticks">A title with ticks</a></p>',
+            $contents
+        );
     }
 
     public function testHeadings() : void

--- a/tests/Builder/input/another.rst
+++ b/tests/Builder/input/another.rst
@@ -15,6 +15,9 @@ test
 title with ampersand &
 ----------------------
 
+A ``title with ticks``
+----------------------
+
 This same title named test exists in other documents. Make sure the link below goes to the one
 in this doc and not the one in the other docs.
 
@@ -27,3 +30,5 @@ see `Another page`_
 see `test`_
 
 see `title with ampersand &`_
+
+see `A title with ticks`_


### PR DESCRIPTION
This is from something we do in the Symfony docs and Sphinx allows. The test case is pretty simple.

However, the fix is a bit ugly... and touches on some deeper parts of this library that are complex and I don't fully understand. However, all tests pass and I've documented my code with a big explanation... eventually if we have enough of these explanations, I'm hoping you can understand things better and can start to improve them.

Thanks!