### PR TITLE
Support documents starting with a literal block marker

### DIFF
--- a/lib/Parser/DocumentParser.php
+++ b/lib/Parser/DocumentParser.php
@@ -235,6 +235,12 @@ class DocumentParser
                         return false;
                     }
 
+                    if (trim($line) === '::') {
+                        $this->isCode = true;
+
+                        return true;
+                    }
+
                     if ($this->lineChecker->isBlockLine($line)) {
                         if ($this->isCode) {
                             $this->setState(State::CODE);

--- a/tests/Functional/tests/code-with-whitespace/code-with-whitespace.html
+++ b/tests/Functional/tests/code-with-whitespace/code-with-whitespace.html
@@ -1,4 +1,2 @@
-<hr />
-<blockquote>
-    <p>Test code block with whitespace.</p>
-</blockquote>
+<pre><code class="">Test code block with whitespace.
+</code></pre>

--- a/tests/Functional/tests/empty-p/empty-p.html
+++ b/tests/Functional/tests/empty-p/empty-p.html
@@ -1,6 +1,3 @@
 <p>Empty paragraph:</p>
-<hr />
-<blockquote>
-    <p>Code</p>
-</blockquote>
+<pre><code class="">Code </code></pre>
 <p>Hello</p>


### PR DESCRIPTION
This fixes https://github.com/weaverryan/docs-builder/issues/36:

> In EasyAdmin docs we have the following in https://github.com/EasyCorp/EasyAdminBundle/blob/master/doc/fields.rst
> 
> ```rst
> Design Options
> ~~~~~~~~~~~~~~
> 
> ::
> 
>     TextField::new('firstName', 'Name')
>         // ...
> ```
> 
> In current symfony.com it's correctly displayed as a code block: [...] However, docs-builder parses it as a blockquote

Related reStructuredText specs section: https://docutils.sourceforge.io/docs/ref/rst/restructuredtext.html#literal-blocks I'm a bit unsure about the tests that I modified. Looking at this spec and Sphinx behavior, the previously expected HTML is not correct. They appear to be introduced in cb831fbb43d7992db7b4c3ed3d8937a31561dbd8, so that also doesn't reveal any original reasoning behind these tests.

---

This was already implemented :smile: 
<s>Meanwhile, I also took some freedom to slightly modify how the functional tests are run. This allows running a specific functional test using:

    vendor/bin/phpunit tests/Functional/FunctionalTest.php \
        --filter testFunctional@code-html

This is very useful for me, as I need to var_dump quite a lot to make sense of this new code base.</s>

---

I'm a bit unsure what version to use for this repository: there is 0.1.x, 0.2.x, 1.0.x and master(and I couldn't find any contributing guidelines, probably because this is a quite internal project). So I just took the default one. Please let me know if this is wrong and I need to rebase.