### PR TITLE
Fix permalinks of titles containing ticks

### DIFF
--- a/lib/Nodes/DocumentNode.php
+++ b/lib/Nodes/DocumentNode.php
@@ -13,11 +13,8 @@ use Exception;
 use function array_unshift;
 use function assert;
 use function count;
-use function explode;
-use function implode;
 use function is_string;
 use function sprintf;
-use function strlen;
 
 class DocumentNode extends Node
 {
@@ -144,7 +141,7 @@ class DocumentNode extends Node
             }
 
             $level       = $node->getLevel();
-            $text        = $this->getTextFromNode($node);
+            $text        = $node->getValue()->getText();
             $redirection = $node->getTarget();
             $value       = $redirection !== '' ? [$text, $redirection] : $text;
 
@@ -245,38 +242,5 @@ class DocumentNode extends Node
                 $currentFileName !== '' ? sprintf(' in file "%s"', $currentFileName) : ''
             ));
         }
-    }
-
-    /**
-     * Fetches the actual "title" text from a TitleNode
-     *
-     * When SpanNode (parent class of TitleNode) sets it
-     * value property, it uses the SpanProcessor. For
-     * some reason, when that class sees literals, it
-     * replaces those with a 40 character sha. See
-     * SpanProcessor::replaceLiterals().
-     *
-     * I'm sure there is a good reason for this. But, when
-     * it comes to getting the "titles" for a Document,
-     * this results in some titles containing these 40 characters
-     * sha's - e.g. "All about abc123abc123abc123abc123...".
-     *
-     * This corrects that by looking back into the Node to
-     * get the original text.
-     */
-    private function getTextFromNode(TitleNode $node): string
-    {
-        $text = $node->getValue()->getValue();
-
-        $words = explode(' ', $text);
-        foreach ($words as $key => $word) {
-            if (strlen($word) !== 40 || ! isset($node->getValue()->getTokens()[$word])) {
-                continue;
-            }
-
-            $words[$key] = $node->getValue()->getTokens()[$word]->get('text');
-        }
-
-        return implode(' ', $words);
     }
 }

--- a/lib/Nodes/SpanNode.php
+++ b/lib/Nodes/SpanNode.php
@@ -17,6 +17,9 @@ class SpanNode extends Node
     /** @var string */
     protected $value;
 
+    /** @var string */
+    private $text;
+
     /** @var Environment */
     protected $environment;
 
@@ -43,6 +46,7 @@ class SpanNode extends Node
         $spanProcessor = new SpanProcessor($this->environment, $span);
 
         $this->value  = $spanProcessor->process();
+        $this->text   = $spanProcessor->getText($this->value);
         $this->tokens = $spanProcessor->getTokens();
     }
 
@@ -62,5 +66,10 @@ class SpanNode extends Node
     public function getEnvironment(): Environment
     {
         return $this->environment;
+    }
+
+    public function getText(): string
+    {
+        return $this->text;
     }
 }

--- a/lib/Nodes/TitleNode.php
+++ b/lib/Nodes/TitleNode.php
@@ -29,7 +29,7 @@ class TitleNode extends Node
 
         $this->level = $level;
         $this->token = $token;
-        $this->id    = Environment::slugify($this->value->getValue());
+        $this->id    = Environment::slugify($this->value->getText());
     }
 
     public function getValue(): SpanNode

--- a/lib/Span/SpanProcessor.php
+++ b/lib/Span/SpanProcessor.php
@@ -69,6 +69,15 @@ class SpanProcessor
         return $this->tokens;
     }
 
+    public function getText(string $value): string
+    {
+        foreach ($this->tokens as $token) {
+            $value = str_replace($token->getId(), $token->get('text'), $value);
+        }
+
+        return $value;
+    }
+
     /**
      * @param string[] $tokenData
      */

--- a/tests/Functional/tests/titles/titles.html
+++ b/tests/Functional/tests/titles/titles.html
@@ -46,4 +46,9 @@
     <h1>
         Second Main Title
     </h1>
+    <div class="section" id="title-with-code-literal">
+        <h2>
+            Title with <code>code literal</code>
+        </h2>
+    </div>
 </div>

--- a/tests/Functional/tests/titles/titles.rst
+++ b/tests/Functional/tests/titles/titles.rst
@@ -32,3 +32,6 @@ em
 
 Second Main Title
 =================
+
+Title with ``code literal``
+---------------------------

--- a/tests/Functional/tests/titles/titles.tex
+++ b/tests/Functional/tests/titles/titles.tex
@@ -27,3 +27,5 @@ Text again
 
 
 \chapter{Second Main Title}
+
+\section{Title with \verb|code literal|}


### PR DESCRIPTION
Hello, 

this fixes https://github.com/weaverryan/docs-builder/pull/45

The problem is related to what @weaverryan fixed here https://github.com/doctrine/rst-parser/pull/124

We actually need a way to access to the "real text" of the `SpanNode` from both `DocumentNode` and `TitleNode`, thus I've moved the logic into `SpanNode` with help of `SpanProcessor`. I've simplified a bit Ryan's `DocumentNode::getTextFromNode()` but no problem to take back his version if we think it's more efficient.
