### PR TITLE
Close api

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,3 +1,14 @@
+# Upgrade to 0.5
+
+## Property visibility changed from protected to private
+
+Some directives and node classes had protected visibility for their properties.
+That has now been changed to private.
+
+## Final classes by default
+
+Many classes have been made final because they were never actually extended.
+
 # Upgrade to 0.4
 
 ## Refactored List Rendering
@@ -14,11 +25,6 @@ classes for HTML and LaTex, which receive the new `ListNode`.
 
 Removed `Doctrine\RST\Parser\ListLine` in favor of `Doctrine\RST\Parser\ListItem`
 and changed signature of `Doctrine\RST\Parser\LineChecker::isListLine()`.
-
-## Property visibility changed from protected to private
-
-Some directives and node classes had protected visibility for their properties.
-That has now been changed to private.
 
 # Upgrade to 0.3
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -15,6 +15,11 @@ classes for HTML and LaTex, which receive the new `ListNode`.
 Removed `Doctrine\RST\Parser\ListLine` in favor of `Doctrine\RST\Parser\ListItem`
 and changed signature of `Doctrine\RST\Parser\LineChecker::isListLine()`.
 
+## Property visibility changed from protected to private
+
+Some directives and node classes had protected visibility for their properties.
+That has now been changed to private.
+
 # Upgrade to 0.3
 
 ## `DefinitionListTerm::$definitions` is a list of `Node`'s instead of `SpanNode`'s

--- a/lib/Builder.php
+++ b/lib/Builder.php
@@ -24,7 +24,7 @@ use function file_exists;
 use function is_dir;
 use function sprintf;
 
-class Builder
+final class Builder
 {
     /** @var Kernel */
     private $kernel;

--- a/lib/Builder/Copier.php
+++ b/lib/Builder/Copier.php
@@ -10,7 +10,7 @@ use function basename;
 use function dirname;
 use function is_dir;
 
-class Copier
+final class Copier
 {
     /** @var Filesystem */
     private $filesystem;

--- a/lib/Builder/ParseQueueProcessor.php
+++ b/lib/Builder/ParseQueueProcessor.php
@@ -12,7 +12,7 @@ use Doctrine\RST\Parser;
 
 use function filemtime;
 
-class ParseQueueProcessor
+final class ParseQueueProcessor
 {
     /** @var Kernel */
     private $kernel;

--- a/lib/Builder/Scanner.php
+++ b/lib/Builder/Scanner.php
@@ -13,7 +13,7 @@ use function sprintf;
 use function strlen;
 use function substr;
 
-class Scanner
+final class Scanner
 {
     /** @var string */
     private $fileExtension;

--- a/lib/Directives/CodeBlock.php
+++ b/lib/Directives/CodeBlock.php
@@ -19,7 +19,7 @@ use function trim;
  *
  *      echo "Hello world!\n";
  */
-class CodeBlock extends Directive
+final class CodeBlock extends Directive
 {
     public function getName(): string
     {

--- a/lib/Directives/Dummy.php
+++ b/lib/Directives/Dummy.php
@@ -7,7 +7,7 @@ namespace Doctrine\RST\Directives;
 use Doctrine\RST\Nodes\Node;
 use Doctrine\RST\Parser;
 
-class Dummy extends Directive
+final class Dummy extends Directive
 {
     public function getName(): string
     {

--- a/lib/Directives/Raw.php
+++ b/lib/Directives/Raw.php
@@ -15,7 +15,7 @@ use Doctrine\RST\Parser;
  *
  *      <u>Undelined!</u>
  */
-class Raw extends Directive
+final class Raw extends Directive
 {
     public function getName(): string
     {

--- a/lib/Directives/Replace.php
+++ b/lib/Directives/Replace.php
@@ -12,7 +12,7 @@ use Doctrine\RST\Parser;
  *
  * .. |test| replace:: The Test String!
  */
-class Replace extends Directive
+final class Replace extends Directive
 {
     public function getName(): string
     {

--- a/lib/Directives/Toctree.php
+++ b/lib/Directives/Toctree.php
@@ -9,7 +9,7 @@ use Doctrine\RST\Parser;
 use Doctrine\RST\Toc\GlobSearcher;
 use Doctrine\RST\Toc\ToctreeBuilder;
 
-class Toctree extends Directive
+final class Toctree extends Directive
 {
     /** @var ToctreeBuilder */
     private $toctreeBuilder;

--- a/lib/FileIncluder.php
+++ b/lib/FileIncluder.php
@@ -15,7 +15,7 @@ use function realpath;
 use function sprintf;
 use function strpos;
 
-class FileIncluder
+final class FileIncluder
 {
     /** @var Environment */
     private $environment;

--- a/lib/Formats/InternalFormat.php
+++ b/lib/Formats/InternalFormat.php
@@ -7,7 +7,7 @@ namespace Doctrine\RST\Formats;
 use Doctrine\RST\Directives\Directive;
 use Doctrine\RST\Renderers\NodeRendererFactory;
 
-class InternalFormat implements Format
+final class InternalFormat implements Format
 {
     /** @var Format */
     private $format;

--- a/lib/HTML/Directives/ClassDirective.php
+++ b/lib/HTML/Directives/ClassDirective.php
@@ -13,7 +13,7 @@ use Doctrine\RST\Parser;
 use function array_map;
 use function explode;
 
-class ClassDirective extends SubDirective
+final class ClassDirective extends SubDirective
 {
     public function getName(): string
     {

--- a/lib/HTML/Directives/Div.php
+++ b/lib/HTML/Directives/Div.php
@@ -11,7 +11,7 @@ use Doctrine\RST\Parser;
 /**
  * Divs a sub document in a div with a given class
  */
-class Div extends SubDirective
+final class Div extends SubDirective
 {
     public function getName(): string
     {

--- a/lib/HTML/Directives/Figure.php
+++ b/lib/HTML/Directives/Figure.php
@@ -20,7 +20,7 @@ use function sprintf;
  *
  *      Here is an awesome caption
  */
-class Figure extends SubDirective
+final class Figure extends SubDirective
 {
     public function getName(): string
     {

--- a/lib/HTML/Directives/Image.php
+++ b/lib/HTML/Directives/Image.php
@@ -18,7 +18,7 @@ use function sprintf;
  *      :width: 100
  *      :title: An image
  */
-class Image extends Directive
+final class Image extends Directive
 {
     public function getName(): string
     {

--- a/lib/HTML/Directives/Meta.php
+++ b/lib/HTML/Directives/Meta.php
@@ -14,7 +14,7 @@ use Doctrine\RST\Parser;
  * .. meta::
  *      :key: value
  */
-class Meta extends Directive
+final class Meta extends Directive
 {
     public function getName(): string
     {

--- a/lib/HTML/Directives/Stylesheet.php
+++ b/lib/HTML/Directives/Stylesheet.php
@@ -13,7 +13,7 @@ use Doctrine\RST\Parser;
  *
  * .. stylesheet:: style.css
  */
-class Stylesheet extends Directive
+final class Stylesheet extends Directive
 {
     public function getName(): string
     {

--- a/lib/HTML/Directives/Title.php
+++ b/lib/HTML/Directives/Title.php
@@ -13,7 +13,7 @@ use Doctrine\RST\Parser;
  *
  * .. title:: Page title
  */
-class Title extends Directive
+final class Title extends Directive
 {
     public function getName(): string
     {

--- a/lib/HTML/Directives/Url.php
+++ b/lib/HTML/Directives/Url.php
@@ -12,7 +12,7 @@ use function trim;
 /**
  * Sets the document URL
  */
-class Url extends Directive
+final class Url extends Directive
 {
     public function getName(): string
     {

--- a/lib/HTML/Directives/Wrap.php
+++ b/lib/HTML/Directives/Wrap.php
@@ -17,10 +17,10 @@ use function uniqid;
 class Wrap extends SubDirective
 {
     /** @var string */
-    protected $class;
+    private $class;
 
     /** @var bool */
-    protected $uniqid;
+    private $uniqid;
 
     public function __construct(string $class, bool $uniqid = false)
     {

--- a/lib/HTML/Directives/Wrap.php
+++ b/lib/HTML/Directives/Wrap.php
@@ -14,7 +14,7 @@ use function uniqid;
 /**
  * Wraps a sub document in a div with a given class
  */
-class Wrap extends SubDirective
+final class Wrap extends SubDirective
 {
     /** @var string */
     private $class;

--- a/lib/HTML/HTMLFormat.php
+++ b/lib/HTML/HTMLFormat.php
@@ -13,7 +13,7 @@ use Doctrine\RST\Renderers\CallableNodeRendererFactory;
 use Doctrine\RST\Renderers\NodeRendererFactory;
 use Doctrine\RST\Templates\TemplateRenderer;
 
-class HTMLFormat implements Format
+final class HTMLFormat implements Format
 {
     /** @var TemplateRenderer */
     private $templateRenderer;

--- a/lib/HTML/Renderers/AnchorNodeRenderer.php
+++ b/lib/HTML/Renderers/AnchorNodeRenderer.php
@@ -8,7 +8,7 @@ use Doctrine\RST\Nodes\AnchorNode;
 use Doctrine\RST\Renderers\NodeRenderer;
 use Doctrine\RST\Templates\TemplateRenderer;
 
-class AnchorNodeRenderer implements NodeRenderer
+final class AnchorNodeRenderer implements NodeRenderer
 {
     /** @var AnchorNode */
     private $anchorNode;

--- a/lib/HTML/Renderers/CodeNodeRenderer.php
+++ b/lib/HTML/Renderers/CodeNodeRenderer.php
@@ -8,7 +8,7 @@ use Doctrine\RST\Nodes\CodeNode;
 use Doctrine\RST\Renderers\NodeRenderer;
 use Doctrine\RST\Templates\TemplateRenderer;
 
-class CodeNodeRenderer implements NodeRenderer
+final class CodeNodeRenderer implements NodeRenderer
 {
     /** @var CodeNode */
     private $codeNode;

--- a/lib/HTML/Renderers/DefinitionListNodeRenderer.php
+++ b/lib/HTML/Renderers/DefinitionListNodeRenderer.php
@@ -8,7 +8,7 @@ use Doctrine\RST\Nodes\DefinitionListNode;
 use Doctrine\RST\Renderers\NodeRenderer;
 use Doctrine\RST\Templates\TemplateRenderer;
 
-class DefinitionListNodeRenderer implements NodeRenderer
+final class DefinitionListNodeRenderer implements NodeRenderer
 {
     /** @var DefinitionListNode */
     private $definitionListNode;

--- a/lib/HTML/Renderers/DocumentNodeRenderer.php
+++ b/lib/HTML/Renderers/DocumentNodeRenderer.php
@@ -11,7 +11,7 @@ use Doctrine\RST\Renderers\NodeRenderer;
 use Doctrine\RST\Templates\TemplateRenderer;
 use Gajus\Dindent\Indenter;
 
-class DocumentNodeRenderer implements NodeRenderer, FullDocumentNodeRenderer
+final class DocumentNodeRenderer implements NodeRenderer, FullDocumentNodeRenderer
 {
     /** @var DocumentNode */
     private $document;

--- a/lib/HTML/Renderers/FigureNodeRenderer.php
+++ b/lib/HTML/Renderers/FigureNodeRenderer.php
@@ -8,7 +8,7 @@ use Doctrine\RST\Nodes\FigureNode;
 use Doctrine\RST\Renderers\NodeRenderer;
 use Doctrine\RST\Templates\TemplateRenderer;
 
-class FigureNodeRenderer implements NodeRenderer
+final class FigureNodeRenderer implements NodeRenderer
 {
     /** @var FigureNode */
     private $figureNode;

--- a/lib/HTML/Renderers/ImageNodeRenderer.php
+++ b/lib/HTML/Renderers/ImageNodeRenderer.php
@@ -8,7 +8,7 @@ use Doctrine\RST\Nodes\ImageNode;
 use Doctrine\RST\Renderers\NodeRenderer;
 use Doctrine\RST\Templates\TemplateRenderer;
 
-class ImageNodeRenderer implements NodeRenderer
+final class ImageNodeRenderer implements NodeRenderer
 {
     /** @var ImageNode */
     private $imageNode;

--- a/lib/HTML/Renderers/MetaNodeRenderer.php
+++ b/lib/HTML/Renderers/MetaNodeRenderer.php
@@ -8,7 +8,7 @@ use Doctrine\RST\Nodes\MetaNode;
 use Doctrine\RST\Renderers\NodeRenderer;
 use Doctrine\RST\Templates\TemplateRenderer;
 
-class MetaNodeRenderer implements NodeRenderer
+final class MetaNodeRenderer implements NodeRenderer
 {
     /** @var MetaNode */
     private $metaNode;

--- a/lib/HTML/Renderers/ParagraphNodeRenderer.php
+++ b/lib/HTML/Renderers/ParagraphNodeRenderer.php
@@ -8,7 +8,7 @@ use Doctrine\RST\Nodes\ParagraphNode;
 use Doctrine\RST\Renderers\NodeRenderer;
 use Doctrine\RST\Templates\TemplateRenderer;
 
-class ParagraphNodeRenderer implements NodeRenderer
+final class ParagraphNodeRenderer implements NodeRenderer
 {
     /** @var ParagraphNode */
     private $paragraphNode;

--- a/lib/HTML/Renderers/QuoteNodeRenderer.php
+++ b/lib/HTML/Renderers/QuoteNodeRenderer.php
@@ -8,7 +8,7 @@ use Doctrine\RST\Nodes\QuoteNode;
 use Doctrine\RST\Renderers\NodeRenderer;
 use Doctrine\RST\Templates\TemplateRenderer;
 
-class QuoteNodeRenderer implements NodeRenderer
+final class QuoteNodeRenderer implements NodeRenderer
 {
     /** @var QuoteNode */
     private $quoteNode;

--- a/lib/HTML/Renderers/SectionBeginNodeRenderer.php
+++ b/lib/HTML/Renderers/SectionBeginNodeRenderer.php
@@ -8,7 +8,7 @@ use Doctrine\RST\Nodes\SectionBeginNode;
 use Doctrine\RST\Renderers\NodeRenderer;
 use Doctrine\RST\Templates\TemplateRenderer;
 
-class SectionBeginNodeRenderer implements NodeRenderer
+final class SectionBeginNodeRenderer implements NodeRenderer
 {
     /** @var SectionBeginNode */
     private $sectionBeginNode;

--- a/lib/HTML/Renderers/SectionEndNodeRenderer.php
+++ b/lib/HTML/Renderers/SectionEndNodeRenderer.php
@@ -8,7 +8,7 @@ use Doctrine\RST\Nodes\SectionEndNode;
 use Doctrine\RST\Renderers\NodeRenderer;
 use Doctrine\RST\Templates\TemplateRenderer;
 
-class SectionEndNodeRenderer implements NodeRenderer
+final class SectionEndNodeRenderer implements NodeRenderer
 {
     /** @var SectionEndNode */
     private $sectionEndNode;

--- a/lib/HTML/Renderers/SeparatorNodeRenderer.php
+++ b/lib/HTML/Renderers/SeparatorNodeRenderer.php
@@ -7,7 +7,7 @@ namespace Doctrine\RST\HTML\Renderers;
 use Doctrine\RST\Renderers\NodeRenderer;
 use Doctrine\RST\Templates\TemplateRenderer;
 
-class SeparatorNodeRenderer implements NodeRenderer
+final class SeparatorNodeRenderer implements NodeRenderer
 {
     /** @var TemplateRenderer */
     private $templateRenderer;

--- a/lib/HTML/Renderers/SpanNodeRenderer.php
+++ b/lib/HTML/Renderers/SpanNodeRenderer.php
@@ -13,7 +13,7 @@ use Doctrine\RST\Templates\TemplateRenderer;
 use function htmlspecialchars;
 use function trim;
 
-class SpanNodeRenderer extends BaseSpanNodeRenderer
+final class SpanNodeRenderer extends BaseSpanNodeRenderer
 {
     /** @var TemplateRenderer */
     private $templateRenderer;

--- a/lib/HTML/Renderers/TableNodeRenderer.php
+++ b/lib/HTML/Renderers/TableNodeRenderer.php
@@ -11,7 +11,7 @@ use LogicException;
 
 use function sprintf;
 
-class TableNodeRenderer implements NodeRenderer
+final class TableNodeRenderer implements NodeRenderer
 {
     /** @var TableNode */
     private $tableNode;

--- a/lib/HTML/Renderers/TitleNodeRenderer.php
+++ b/lib/HTML/Renderers/TitleNodeRenderer.php
@@ -8,7 +8,7 @@ use Doctrine\RST\Nodes\TitleNode;
 use Doctrine\RST\Renderers\NodeRenderer;
 use Doctrine\RST\Templates\TemplateRenderer;
 
-class TitleNodeRenderer implements NodeRenderer
+final class TitleNodeRenderer implements NodeRenderer
 {
     /** @var TitleNode */
     private $titleNode;

--- a/lib/HTML/Renderers/TocNodeRenderer.php
+++ b/lib/HTML/Renderers/TocNodeRenderer.php
@@ -12,7 +12,7 @@ use Doctrine\RST\Templates\TemplateRenderer;
 use function count;
 use function is_array;
 
-class TocNodeRenderer implements NodeRenderer
+final class TocNodeRenderer implements NodeRenderer
 {
     /** @var Environment */
     private $environment;

--- a/lib/InvalidLink.php
+++ b/lib/InvalidLink.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\RST;
 
-class InvalidLink
+final class InvalidLink
 {
     /** @var string */
     private $name;

--- a/lib/LaTeX/Directives/Image.php
+++ b/lib/LaTeX/Directives/Image.php
@@ -18,7 +18,7 @@ use function sprintf;
  *      :width: 100
  *      :title: An image
  */
-class Image extends Directive
+final class Image extends Directive
 {
     public function getName(): string
     {

--- a/lib/LaTeX/Directives/LaTeXMain.php
+++ b/lib/LaTeX/Directives/LaTeXMain.php
@@ -11,7 +11,7 @@ use Doctrine\RST\Parser;
 /**
  * Marks the document as LaTeX main
  */
-class LaTeXMain extends Directive
+final class LaTeXMain extends Directive
 {
     public function getName(): string
     {

--- a/lib/LaTeX/Directives/Meta.php
+++ b/lib/LaTeX/Directives/Meta.php
@@ -14,7 +14,7 @@ use Doctrine\RST\Parser;
  * .. meta::
  *      :key: value
  */
-class Meta extends Directive
+final class Meta extends Directive
 {
     public function getName(): string
     {

--- a/lib/LaTeX/Directives/Stylesheet.php
+++ b/lib/LaTeX/Directives/Stylesheet.php
@@ -13,7 +13,7 @@ use Doctrine\RST\Parser;
  *
  * .. stylesheet:: style.css
  */
-class Stylesheet extends Directive
+final class Stylesheet extends Directive
 {
     public function getName(): string
     {

--- a/lib/LaTeX/Directives/Title.php
+++ b/lib/LaTeX/Directives/Title.php
@@ -13,7 +13,7 @@ use Doctrine\RST\Parser;
  *
  * .. title:: Page title
  */
-class Title extends Directive
+final class Title extends Directive
 {
     public function getName(): string
     {

--- a/lib/LaTeX/Directives/Url.php
+++ b/lib/LaTeX/Directives/Url.php
@@ -12,7 +12,7 @@ use function trim;
 /**
  * Sets the document URL
  */
-class Url extends Directive
+final class Url extends Directive
 {
     public function getName(): string
     {

--- a/lib/LaTeX/Directives/Wrap.php
+++ b/lib/LaTeX/Directives/Wrap.php
@@ -11,7 +11,7 @@ use Doctrine\RST\Parser;
 /**
  * Wraps a sub document in a div with a given class
  */
-class Wrap extends SubDirective
+final class Wrap extends SubDirective
 {
     /** @var string */
     private $class;

--- a/lib/LaTeX/Directives/Wrap.php
+++ b/lib/LaTeX/Directives/Wrap.php
@@ -14,7 +14,7 @@ use Doctrine\RST\Parser;
 class Wrap extends SubDirective
 {
     /** @var string */
-    protected $class;
+    private $class;
 
     public function __construct(string $class)
     {

--- a/lib/LaTeX/LaTeXFormat.php
+++ b/lib/LaTeX/LaTeXFormat.php
@@ -13,7 +13,7 @@ use Doctrine\RST\Renderers\CallableNodeRendererFactory;
 use Doctrine\RST\Renderers\NodeRendererFactory;
 use Doctrine\RST\Templates\TemplateRenderer;
 
-class LaTeXFormat implements Format
+final class LaTeXFormat implements Format
 {
     /** @var TemplateRenderer */
     private $templateRenderer;

--- a/lib/LaTeX/Renderers/AnchorNodeRenderer.php
+++ b/lib/LaTeX/Renderers/AnchorNodeRenderer.php
@@ -8,7 +8,7 @@ use Doctrine\RST\Nodes\AnchorNode;
 use Doctrine\RST\Renderers\NodeRenderer;
 use Doctrine\RST\Templates\TemplateRenderer;
 
-class AnchorNodeRenderer implements NodeRenderer
+final class AnchorNodeRenderer implements NodeRenderer
 {
     /** @var AnchorNode */
     private $anchorNode;

--- a/lib/LaTeX/Renderers/CodeNodeRenderer.php
+++ b/lib/LaTeX/Renderers/CodeNodeRenderer.php
@@ -8,7 +8,7 @@ use Doctrine\RST\Nodes\CodeNode;
 use Doctrine\RST\Renderers\NodeRenderer;
 use Doctrine\RST\Templates\TemplateRenderer;
 
-class CodeNodeRenderer implements NodeRenderer
+final class CodeNodeRenderer implements NodeRenderer
 {
     /** @var CodeNode */
     private $codeNode;

--- a/lib/LaTeX/Renderers/DocumentNodeRenderer.php
+++ b/lib/LaTeX/Renderers/DocumentNodeRenderer.php
@@ -13,7 +13,7 @@ use Doctrine\RST\Templates\TemplateRenderer;
 
 use function count;
 
-class DocumentNodeRenderer implements NodeRenderer, FullDocumentNodeRenderer
+final class DocumentNodeRenderer implements NodeRenderer, FullDocumentNodeRenderer
 {
     /** @var DocumentNode */
     private $document;

--- a/lib/LaTeX/Renderers/ImageNodeRenderer.php
+++ b/lib/LaTeX/Renderers/ImageNodeRenderer.php
@@ -8,7 +8,7 @@ use Doctrine\RST\Nodes\ImageNode;
 use Doctrine\RST\Renderers\NodeRenderer;
 use Doctrine\RST\Templates\TemplateRenderer;
 
-class ImageNodeRenderer implements NodeRenderer
+final class ImageNodeRenderer implements NodeRenderer
 {
     /** @var ImageNode */
     private $imageNode;

--- a/lib/LaTeX/Renderers/LaTexMainNodeRenderer.php
+++ b/lib/LaTeX/Renderers/LaTexMainNodeRenderer.php
@@ -6,7 +6,7 @@ namespace Doctrine\RST\LaTeX\Renderers;
 
 use Doctrine\RST\Renderers\NodeRenderer;
 
-class LaTexMainNodeRenderer implements NodeRenderer
+final class LaTexMainNodeRenderer implements NodeRenderer
 {
     public function render(): string
     {

--- a/lib/LaTeX/Renderers/MetaNodeRenderer.php
+++ b/lib/LaTeX/Renderers/MetaNodeRenderer.php
@@ -8,7 +8,7 @@ use Doctrine\RST\Nodes\MetaNode;
 use Doctrine\RST\Renderers\NodeRenderer;
 use Doctrine\RST\Templates\TemplateRenderer;
 
-class MetaNodeRenderer implements NodeRenderer
+final class MetaNodeRenderer implements NodeRenderer
 {
     /** @var MetaNode */
     private $metaNode;

--- a/lib/LaTeX/Renderers/ParagraphNodeRenderer.php
+++ b/lib/LaTeX/Renderers/ParagraphNodeRenderer.php
@@ -8,7 +8,7 @@ use Doctrine\RST\Nodes\ParagraphNode;
 use Doctrine\RST\Renderers\NodeRenderer;
 use Doctrine\RST\Templates\TemplateRenderer;
 
-class ParagraphNodeRenderer implements NodeRenderer
+final class ParagraphNodeRenderer implements NodeRenderer
 {
     /** @var ParagraphNode */
     private $paragraphNode;

--- a/lib/LaTeX/Renderers/QuoteNodeRenderer.php
+++ b/lib/LaTeX/Renderers/QuoteNodeRenderer.php
@@ -8,7 +8,7 @@ use Doctrine\RST\Nodes\QuoteNode;
 use Doctrine\RST\Renderers\NodeRenderer;
 use Doctrine\RST\Templates\TemplateRenderer;
 
-class QuoteNodeRenderer implements NodeRenderer
+final class QuoteNodeRenderer implements NodeRenderer
 {
     /** @var QuoteNode */
     private $quoteNode;

--- a/lib/LaTeX/Renderers/SeparatorNodeRenderer.php
+++ b/lib/LaTeX/Renderers/SeparatorNodeRenderer.php
@@ -7,7 +7,7 @@ namespace Doctrine\RST\LaTeX\Renderers;
 use Doctrine\RST\Renderers\NodeRenderer;
 use Doctrine\RST\Templates\TemplateRenderer;
 
-class SeparatorNodeRenderer implements NodeRenderer
+final class SeparatorNodeRenderer implements NodeRenderer
 {
     /** @var TemplateRenderer */
     private $templateRenderer;

--- a/lib/LaTeX/Renderers/SpanNodeRenderer.php
+++ b/lib/LaTeX/Renderers/SpanNodeRenderer.php
@@ -14,7 +14,7 @@ use function is_string;
 use function substr;
 use function trim;
 
-class SpanNodeRenderer extends BaseSpanNodeRenderer
+final class SpanNodeRenderer extends BaseSpanNodeRenderer
 {
     /** @var TemplateRenderer */
     private $templateRenderer;

--- a/lib/LaTeX/Renderers/TableNodeRenderer.php
+++ b/lib/LaTeX/Renderers/TableNodeRenderer.php
@@ -11,7 +11,7 @@ use function count;
 use function implode;
 use function max;
 
-class TableNodeRenderer implements NodeRenderer
+final class TableNodeRenderer implements NodeRenderer
 {
     /** @var TableNode */
     private $tableNode;

--- a/lib/LaTeX/Renderers/TitleNodeRenderer.php
+++ b/lib/LaTeX/Renderers/TitleNodeRenderer.php
@@ -8,7 +8,7 @@ use Doctrine\RST\Nodes\TitleNode;
 use Doctrine\RST\Renderers\NodeRenderer;
 use Doctrine\RST\Templates\TemplateRenderer;
 
-class TitleNodeRenderer implements NodeRenderer
+final class TitleNodeRenderer implements NodeRenderer
 {
     /** @var TitleNode */
     private $titleNode;

--- a/lib/LaTeX/Renderers/TocNodeRenderer.php
+++ b/lib/LaTeX/Renderers/TocNodeRenderer.php
@@ -9,7 +9,7 @@ use Doctrine\RST\Nodes\TocNode;
 use Doctrine\RST\Renderers\NodeRenderer;
 use Doctrine\RST\Templates\TemplateRenderer;
 
-class TocNodeRenderer implements NodeRenderer
+final class TocNodeRenderer implements NodeRenderer
 {
     /** @var Environment */
     private $environment;

--- a/lib/NodeFactory/DefaultNodeFactory.php
+++ b/lib/NodeFactory/DefaultNodeFactory.php
@@ -41,7 +41,7 @@ use InvalidArgumentException;
 use function assert;
 use function sprintf;
 
-class DefaultNodeFactory implements NodeFactory
+final class DefaultNodeFactory implements NodeFactory
 {
     /** @var EventManager */
     private $eventManager;

--- a/lib/Nodes/BlockNode.php
+++ b/lib/Nodes/BlockNode.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\RST\Nodes;
 
-class BlockNode extends Node
+final class BlockNode extends Node
 {
     /** @var string */
     protected $value;

--- a/lib/Nodes/CallableNode.php
+++ b/lib/Nodes/CallableNode.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\RST\Nodes;
 
-class CallableNode extends Node
+final class CallableNode extends Node
 {
     /** @var callable */
     private $callable;

--- a/lib/Nodes/CodeNode.php
+++ b/lib/Nodes/CodeNode.php
@@ -17,10 +17,10 @@ class CodeNode extends Node
     protected $value;
 
     /** @var bool */
-    protected $raw = false;
+    private $raw = false;
 
     /** @var string|null */
-    protected $language = null;
+    private $language = null;
 
     /** @var string[] */
     private $options = [];

--- a/lib/Nodes/DefinitionListNode.php
+++ b/lib/Nodes/DefinitionListNode.php
@@ -6,7 +6,7 @@ namespace Doctrine\RST\Nodes;
 
 use Doctrine\RST\Parser\DefinitionList;
 
-class DefinitionListNode extends Node
+final class DefinitionListNode extends Node
 {
     /** @var DefinitionList */
     private $definitionList;

--- a/lib/Nodes/DocumentNode.php
+++ b/lib/Nodes/DocumentNode.php
@@ -22,16 +22,16 @@ class DocumentNode extends Node
     protected $environment;
 
     /** @var Configuration */
-    protected $configuration;
+    private $configuration;
 
     /** @var ErrorManager */
-    protected $errorManager;
+    private $errorManager;
 
     /** @var Node[] */
-    protected $headerNodes = [];
+    private $headerNodes = [];
 
     /** @var Node[] */
-    protected $nodes = [];
+    private $nodes = [];
 
     public function __construct(Environment $environment)
     {

--- a/lib/Nodes/DummyNode.php
+++ b/lib/Nodes/DummyNode.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\RST\Nodes;
 
-class DummyNode extends Node
+final class DummyNode extends Node
 {
     /** @var mixed[] */
     public $data;

--- a/lib/Nodes/FigureNode.php
+++ b/lib/Nodes/FigureNode.php
@@ -7,10 +7,10 @@ namespace Doctrine\RST\Nodes;
 class FigureNode extends Node
 {
     /** @var ImageNode */
-    protected $image;
+    private $image;
 
     /** @var Node|null */
-    protected $document;
+    private $document;
 
     public function __construct(ImageNode $image, ?Node $document = null)
     {

--- a/lib/Nodes/FigureNode.php
+++ b/lib/Nodes/FigureNode.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\RST\Nodes;
 
-class FigureNode extends Node
+final class FigureNode extends Node
 {
     /** @var ImageNode */
     private $image;

--- a/lib/Nodes/ImageNode.php
+++ b/lib/Nodes/ImageNode.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\RST\Nodes;
 
-class ImageNode extends Node
+final class ImageNode extends Node
 {
     /** @var string */
     private $url;

--- a/lib/Nodes/ImageNode.php
+++ b/lib/Nodes/ImageNode.php
@@ -7,10 +7,10 @@ namespace Doctrine\RST\Nodes;
 class ImageNode extends Node
 {
     /** @var string */
-    protected $url;
+    private $url;
 
     /** @var string[] */
-    protected $options;
+    private $options;
 
     /**
      * @param string[] $options

--- a/lib/Nodes/MainNode.php
+++ b/lib/Nodes/MainNode.php
@@ -4,6 +4,6 @@ declare(strict_types=1);
 
 namespace Doctrine\RST\Nodes;
 
-class MainNode extends Node
+final class MainNode extends Node
 {
 }

--- a/lib/Nodes/MetaNode.php
+++ b/lib/Nodes/MetaNode.php
@@ -7,7 +7,7 @@ namespace Doctrine\RST\Nodes;
 class MetaNode extends Node
 {
     /** @var string */
-    protected $key;
+    private $key;
 
     /** @var string */
     protected $value;

--- a/lib/Nodes/MetaNode.php
+++ b/lib/Nodes/MetaNode.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\RST\Nodes;
 
-class MetaNode extends Node
+final class MetaNode extends Node
 {
     /** @var string */
     private $key;

--- a/lib/Nodes/Node.php
+++ b/lib/Nodes/Node.php
@@ -34,7 +34,7 @@ abstract class Node
     protected $value;
 
     /** @var string[] */
-    protected $classes = [];
+    private $classes = [];
 
     /**
      * @param Node|string|null $value

--- a/lib/Nodes/RawNode.php
+++ b/lib/Nodes/RawNode.php
@@ -4,6 +4,6 @@ declare(strict_types=1);
 
 namespace Doctrine\RST\Nodes;
 
-class RawNode extends Node
+final class RawNode extends Node
 {
 }

--- a/lib/Nodes/SectionBeginNode.php
+++ b/lib/Nodes/SectionBeginNode.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\RST\Nodes;
 
-class SectionBeginNode extends Node
+final class SectionBeginNode extends Node
 {
     /** @var TitleNode */
     private $titleNode;

--- a/lib/Nodes/SectionEndNode.php
+++ b/lib/Nodes/SectionEndNode.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\RST\Nodes;
 
-class SectionEndNode extends Node
+final class SectionEndNode extends Node
 {
     /** @var TitleNode */
     private $titleNode;

--- a/lib/Nodes/SeparatorNode.php
+++ b/lib/Nodes/SeparatorNode.php
@@ -7,7 +7,7 @@ namespace Doctrine\RST\Nodes;
 class SeparatorNode extends Node
 {
     /** @var int */
-    protected $level;
+    private $level;
 
     public function __construct(int $level)
     {

--- a/lib/Nodes/SpanNode.php
+++ b/lib/Nodes/SpanNode.php
@@ -24,7 +24,7 @@ class SpanNode extends Node
     protected $environment;
 
     /** @var SpanToken[] */
-    protected $tokens;
+    private $tokens;
 
     /**
      * @param string|string[]|SpanNode $span

--- a/lib/Nodes/TitleNode.php
+++ b/lib/Nodes/TitleNode.php
@@ -12,16 +12,16 @@ class TitleNode extends Node
     protected $value;
 
     /** @var int */
-    protected $level;
+    private $level;
 
     /** @var string */
     protected $token;
 
     /** @var string */
-    protected $id;
+    private $id;
 
     /** @var string */
-    protected $target = '';
+    private $target = '';
 
     public function __construct(Node $value, int $level, string $token)
     {

--- a/lib/Nodes/TocNode.php
+++ b/lib/Nodes/TocNode.php
@@ -14,10 +14,10 @@ class TocNode extends Node
     protected $environment;
 
     /** @var string[] */
-    protected $files;
+    private $files;
 
     /** @var string[] */
-    protected $options;
+    private $options;
 
     /**
      * @param string[] $files

--- a/lib/Nodes/WrapperNode.php
+++ b/lib/Nodes/WrapperNode.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\RST\Nodes;
 
-class WrapperNode extends Node
+final class WrapperNode extends Node
 {
     /** @var Node|null */
     private $node;

--- a/lib/Nodes/WrapperNode.php
+++ b/lib/Nodes/WrapperNode.php
@@ -7,13 +7,13 @@ namespace Doctrine\RST\Nodes;
 class WrapperNode extends Node
 {
     /** @var Node|null */
-    protected $node;
+    private $node;
 
     /** @var string */
-    protected $before;
+    private $before;
 
     /** @var string */
-    protected $after;
+    private $after;
 
     public function __construct(?Node $node, string $before = '', string $after = '')
     {

--- a/lib/Parser/Buffer.php
+++ b/lib/Parser/Buffer.php
@@ -8,7 +8,7 @@ use function array_pop;
 use function count;
 use function implode;
 
-class Buffer
+final class Buffer
 {
     /** @var string[] */
     private $lines = [];

--- a/lib/Parser/DefinitionList.php
+++ b/lib/Parser/DefinitionList.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\RST\Parser;
 
-class DefinitionList
+final class DefinitionList
 {
     /** @var DefinitionListTerm[] */
     private $terms = [];

--- a/lib/Parser/DefinitionListTerm.php
+++ b/lib/Parser/DefinitionListTerm.php
@@ -8,7 +8,7 @@ use Doctrine\RST\Nodes\Node;
 use Doctrine\RST\Nodes\SpanNode;
 use RuntimeException;
 
-class DefinitionListTerm
+final class DefinitionListTerm
 {
     /** @var SpanNode */
     private $term;

--- a/lib/Parser/Directive.php
+++ b/lib/Parser/Directive.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\RST\Parser;
 
-class Directive
+final class Directive
 {
     /** @var string */
     private $variable;

--- a/lib/Parser/DirectiveOption.php
+++ b/lib/Parser/DirectiveOption.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\RST\Parser;
 
-class DirectiveOption
+final class DirectiveOption
 {
     /** @var string */
     private $name;

--- a/lib/Parser/DocumentParser.php
+++ b/lib/Parser/DocumentParser.php
@@ -32,7 +32,7 @@ use function strlen;
 use function substr;
 use function trim;
 
-class DocumentParser
+final class DocumentParser
 {
     /** @var Parser */
     private $parser;

--- a/lib/Parser/LineDataParser.php
+++ b/lib/Parser/LineDataParser.php
@@ -20,7 +20,7 @@ use function strlen;
 use function substr;
 use function trim;
 
-class LineDataParser
+final class LineDataParser
 {
     /** @var Parser */
     private $parser;

--- a/lib/Parser/Lines.php
+++ b/lib/Parser/Lines.php
@@ -9,7 +9,7 @@ use Iterator;
 /**
  * @template-implements Iterator<array-key, string>
  */
-class Lines implements Iterator
+final class Lines implements Iterator
 {
     /** @var string[] */
     private $lines = [];

--- a/lib/Parser/Link.php
+++ b/lib/Parser/Link.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\RST\Parser;
 
-class Link
+final class Link
 {
     public const TYPE_LINK   = 'link';
     public const TYPE_ANCHOR = 'anchor';

--- a/lib/Parser/State.php
+++ b/lib/Parser/State.php
@@ -7,7 +7,7 @@ namespace Doctrine\RST\Parser;
 /**
  * "States" for DocumentParser as it parses line-by-line.
  */
-class State
+final class State
 {
     /**
      * There is currently no state: the next line will begin a new state

--- a/lib/Parser/TableParser.php
+++ b/lib/Parser/TableParser.php
@@ -13,7 +13,7 @@ use function sprintf;
 use function strlen;
 use function trim;
 
-class TableParser
+final class TableParser
 {
     private const SIMPLE_TABLE_LETTER = '=';
     // "-" is valid as a separator in a simple table, except

--- a/lib/References/Doc.php
+++ b/lib/References/Doc.php
@@ -6,7 +6,7 @@ namespace Doctrine\RST\References;
 
 use Doctrine\RST\Environment;
 
-class Doc extends Reference
+final class Doc extends Reference
 {
     /** @var string */
     private $name;

--- a/lib/References/ResolvedReference.php
+++ b/lib/References/ResolvedReference.php
@@ -10,7 +10,7 @@ use function is_string;
 use function preg_match;
 use function sprintf;
 
-class ResolvedReference
+final class ResolvedReference
 {
     /** @var ?string */
     private $file;

--- a/lib/References/Resolver.php
+++ b/lib/References/Resolver.php
@@ -7,7 +7,7 @@ namespace Doctrine\RST\References;
 use Doctrine\RST\Environment;
 use Doctrine\RST\Meta\MetaEntry;
 
-class Resolver
+final class Resolver
 {
     /**
      * @param string[] $attributes

--- a/lib/Renderers/CallableNodeRenderer.php
+++ b/lib/Renderers/CallableNodeRenderer.php
@@ -6,7 +6,7 @@ namespace Doctrine\RST\Renderers;
 
 use Doctrine\RST\Nodes\CallableNode;
 
-class CallableNodeRenderer implements NodeRenderer
+final class CallableNodeRenderer implements NodeRenderer
 {
     /** @var CallableNode */
     private $callableNode;

--- a/lib/Renderers/CallableNodeRendererFactory.php
+++ b/lib/Renderers/CallableNodeRendererFactory.php
@@ -6,7 +6,7 @@ namespace Doctrine\RST\Renderers;
 
 use Doctrine\RST\Nodes\Node;
 
-class CallableNodeRendererFactory implements NodeRendererFactory
+final class CallableNodeRendererFactory implements NodeRendererFactory
 {
     /** @var callable */
     private $callable;

--- a/lib/Renderers/DefaultNodeRenderer.php
+++ b/lib/Renderers/DefaultNodeRenderer.php
@@ -6,7 +6,7 @@ namespace Doctrine\RST\Renderers;
 
 use Doctrine\RST\Nodes\Node;
 
-class DefaultNodeRenderer implements NodeRenderer
+final class DefaultNodeRenderer implements NodeRenderer
 {
     /** @var Node */
     private $node;

--- a/lib/Renderers/DocumentNodeRenderer.php
+++ b/lib/Renderers/DocumentNodeRenderer.php
@@ -6,7 +6,7 @@ namespace Doctrine\RST\Renderers;
 
 use Doctrine\RST\Nodes\DocumentNode;
 
-class DocumentNodeRenderer implements NodeRenderer
+final class DocumentNodeRenderer implements NodeRenderer
 {
     /** @var DocumentNode */
     private $document;

--- a/lib/Renderers/RenderedNode.php
+++ b/lib/Renderers/RenderedNode.php
@@ -6,7 +6,7 @@ namespace Doctrine\RST\Renderers;
 
 use Doctrine\RST\Nodes\Node;
 
-class RenderedNode
+final class RenderedNode
 {
     /** @var Node */
     private $node;

--- a/lib/Span/SpanProcessor.php
+++ b/lib/Span/SpanProcessor.php
@@ -19,7 +19,7 @@ use function str_replace;
 use function substr;
 use function time;
 
-class SpanProcessor
+final class SpanProcessor
 {
     /** @var Environment */
     private $environment;

--- a/lib/Span/SpanToken.php
+++ b/lib/Span/SpanToken.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\RST\Span;
 
-class SpanToken
+final class SpanToken
 {
     public const TYPE_LITERAL   = 'literal';
     public const TYPE_REFERENCE = 'reference';

--- a/lib/Templates/TwigAdapter.php
+++ b/lib/Templates/TwigAdapter.php
@@ -7,7 +7,7 @@ namespace Doctrine\RST\Templates;
 use Doctrine\RST\Configuration;
 use Twig\Environment as TwigEnvironment;
 
-class TwigAdapter implements TemplateEngineAdapter
+final class TwigAdapter implements TemplateEngineAdapter
 {
     /** @var Configuration */
     private $configuration;

--- a/lib/Templates/TwigEnvironmentFactory.php
+++ b/lib/Templates/TwigEnvironmentFactory.php
@@ -11,7 +11,7 @@ use Twig\Loader\FilesystemLoader;
 use function file_exists;
 use function sprintf;
 
-class TwigEnvironmentFactory
+final class TwigEnvironmentFactory
 {
     public static function createTwigEnvironment(Configuration $configuration): TwigEnvironment
     {

--- a/lib/Templates/TwigTemplateRenderer.php
+++ b/lib/Templates/TwigTemplateRenderer.php
@@ -8,7 +8,7 @@ use Doctrine\RST\Configuration;
 
 use function rtrim;
 
-class TwigTemplateRenderer implements TemplateRenderer
+final class TwigTemplateRenderer implements TemplateRenderer
 {
     /** @var Configuration */
     private $configuration;

--- a/lib/Toc/ToctreeBuilder.php
+++ b/lib/Toc/ToctreeBuilder.php
@@ -15,7 +15,7 @@ use function explode;
 use function in_array;
 use function strpos;
 
-class ToctreeBuilder
+final class ToctreeBuilder
 {
     /** @var GlobSearcher */
     private $globSearcher;

--- a/lib/UrlGenerator.php
+++ b/lib/UrlGenerator.php
@@ -15,7 +15,7 @@ use function rtrim;
 use function strpos;
 use function substr;
 
-class UrlGenerator
+final class UrlGenerator
 {
     /** @var Configuration */
     private $configuration;


### PR DESCRIPTION
There are a lot of protected variables that are not referenced in child classes, and most classes were final although they were never extended. `final` can of course be dropped in the future on classes that truly need it. Note that many classes are still not final because they are mocked in tests