### PR TITLE
Adding an Error object

### DIFF
--- a/lib/Environment.php
+++ b/lib/Environment.php
@@ -473,11 +473,17 @@ class Environment
         return $this->titleLetters;
     }
 
+    /**
+     * @deprecated use $this->getErrorManager()->addError() instead.
+     */
     public function addError(string $message, ?Throwable $throwable = null): void
     {
         $this->errorManager->error($message, $throwable);
     }
 
+    /**
+     * @deprecated use $this->getErrorManager()->addWarning() instead.
+     */
     public function addWarning(string $message): void
     {
         $this->errorManager->warning($message);
@@ -508,10 +514,9 @@ class Environment
 
     private function addMissingReferenceSectionError(string $section): void
     {
-        $this->errorManager->error(sprintf(
-            'Unknown reference section "%s"%s',
-            $section,
-            $this->getCurrentFileName() !== '' ? sprintf(' in "%s" ', $this->getCurrentFileName()) : ''
-        ));
+        $this->errorManager->addError(
+            sprintf('Unknown reference section "%s"', $section),
+            $this->getCurrentFileName()
+        );
     }
 }

--- a/lib/Environment.php
+++ b/lib/Environment.php
@@ -11,7 +11,6 @@ use Doctrine\RST\References\Reference;
 use Doctrine\RST\References\ResolvedReference;
 use Doctrine\RST\Templates\TemplateRenderer;
 use InvalidArgumentException;
-use Throwable;
 
 use function array_shift;
 use function dirname;
@@ -473,22 +472,6 @@ class Environment
         return $this->titleLetters;
     }
 
-    /**
-     * @deprecated use $this->getErrorManager()->addError() instead.
-     */
-    public function addError(string $message, ?Throwable $throwable = null): void
-    {
-        $this->errorManager->error($message, $throwable);
-    }
-
-    /**
-     * @deprecated use $this->getErrorManager()->addWarning() instead.
-     */
-    public function addWarning(string $message): void
-    {
-        $this->errorManager->warning($message);
-    }
-
     public static function slugify(string $text): string
     {
         // replace non letter or digits by -
@@ -514,7 +497,7 @@ class Environment
 
     private function addMissingReferenceSectionError(string $section): void
     {
-        $this->errorManager->addError(
+        $this->errorManager->error(
             sprintf('Unknown reference section "%s"', $section),
             $this->getCurrentFileName()
         );

--- a/lib/Error.php
+++ b/lib/Error.php
@@ -34,10 +34,10 @@ final class Error
     {
         $output = $this->message;
         if ($this->getFile() !== null) {
-            $output .= sprintf(' in "%s"', $this->file);
+            $output .= sprintf(' in file "%s"', $this->file);
 
             if ($this->line !== null) {
-                $output .= sprintf(' at line "%d"', $this->line);
+                $output .= sprintf(' at line %d', $this->line);
             }
         }
 

--- a/lib/Error.php
+++ b/lib/Error.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\RST;
+
+use Throwable;
+
+use function sprintf;
+
+final class Error
+{
+    /** @var string */
+    private $message;
+
+    /** @var string|null */
+    private $file;
+
+    /** @var int|null */
+    private $line;
+
+    /** @var Throwable|null */
+    private $throwable;
+
+    public function __construct(string $message, ?string $file = null, ?int $line = null, ?Throwable $throwable = null)
+    {
+        $this->message   = $message;
+        $this->file      = $file;
+        $this->line      = $line;
+        $this->throwable = $throwable;
+    }
+
+    public function asString(): string
+    {
+        $output = $this->message;
+        if ($this->getFile() !== null) {
+            $output .= sprintf(' in "%s"', $this->file);
+
+            if ($this->line !== null) {
+                $output .= sprintf(' at line "%d"', $this->line);
+            }
+        }
+
+        return $output;
+    }
+
+    public function getMessage(): string
+    {
+        return $this->message;
+    }
+
+    public function getFile(): ?string
+    {
+        if ($this->file === '') {
+            return null;
+        }
+
+        return $this->file;
+    }
+
+    public function getLine(): ?int
+    {
+        return $this->line;
+    }
+
+    public function getThrowable(): ?Throwable
+    {
+        return $this->throwable;
+    }
+}

--- a/lib/ErrorManager.php
+++ b/lib/ErrorManager.php
@@ -7,12 +7,14 @@ namespace Doctrine\RST;
 use Exception;
 use Throwable;
 
+use function sprintf;
+
 class ErrorManager
 {
     /** @var Configuration */
     private $configuration;
 
-    /** @var string[] */
+    /** @var list<Error> */
     private $errors = [];
 
     public function __construct(Configuration $configuration)
@@ -20,9 +22,69 @@ class ErrorManager
         $this->configuration = $configuration;
     }
 
+    public function addError(string $message, ?string $file = null, ?int $line = null, ?Throwable $throwable = null): void
+    {
+        $this->errors[] = $error = new Error($message, $file, $line, $throwable);
+
+        if (! $this->configuration->isSilentOnError()) {
+            if ($this->configuration->getOutputFormat() === Configuration::OUTPUT_FORMAT_GITHUB) {
+                $file = $error->getFile();
+                echo sprintf(
+                    '::error %s%s::%s',
+                    $file !== null ? 'file=' . $file : '',
+                    $file !== null && $error->getLine() !== null ? ',linefile=' . $error->getLine() : '',
+                    $error->getMessage()
+                );
+            } else {
+                echo '⚠️ ' . $error->asString() . "\n";
+            }
+        }
+
+        if ($this->configuration->isAbortOnError()) {
+            throw new Exception($error->asString(), 0, $error->getThrowable());
+        }
+    }
+
+    public function addWarning(string $message, ?string $file = null, ?int $line = null, ?Throwable $throwable = null): void
+    {
+        if ($this->configuration->isWarningsAsError()) {
+            $this->addError($message, $file, $line, $throwable);
+
+            return;
+        }
+
+        if ($this->configuration->isSilentOnError()) {
+            return;
+        }
+
+        $error = new Error($message, $file, $line, $throwable);
+        if ($this->configuration->getOutputFormat() === Configuration::OUTPUT_FORMAT_GITHUB) {
+            $file = $error->getFile();
+            echo sprintf(
+                '::warning %s%s::%s',
+                $file !== null ? 'file=' . $file : '',
+                $file !== null && $error->getLine() !== null ? ',linefile=' . $error->getLine() : '',
+                $error->getMessage()
+            );
+        } else {
+            echo $error->asString() . "\n";
+        }
+    }
+
+    /**
+     * @return list<Error>
+     */
+    public function getAllErrors(): array
+    {
+        return $this->errors;
+    }
+
+    /**
+     * @deprecated Use addError() instead
+     */
     public function error(string $message, ?Throwable $throwable = null): void
     {
-        $this->errors[] = $message;
+        $this->errors[] = new Error($message, null, null, $throwable);
 
         if (! $this->configuration->isSilentOnError()) {
             echo '/!\\ ' . $message . "\n";
@@ -33,6 +95,9 @@ class ErrorManager
         }
     }
 
+    /**
+     * @deprecated Use addWarning() instead
+     */
     public function warning(string $message): void
     {
         if ($this->configuration->isWarningsAsError()) {
@@ -49,10 +114,17 @@ class ErrorManager
     }
 
     /**
+     * @deprecated use getAllErrors() instead
+     *
      * @return string[]
      */
     public function getErrors(): array
     {
-        return $this->errors;
+        $outputs = [];
+        foreach ($this->errors as $error) {
+            $outputs[] = $error->asString();
+        }
+
+        return $outputs;
     }
 }

--- a/lib/ErrorManager.php
+++ b/lib/ErrorManager.php
@@ -22,7 +22,7 @@ class ErrorManager
         $this->configuration = $configuration;
     }
 
-    public function addError(string $message, ?string $file = null, ?int $line = null, ?Throwable $throwable = null): void
+    public function error(string $message, ?string $file = null, ?int $line = null, ?Throwable $throwable = null): void
     {
         $this->errors[] = $error = new Error($message, $file, $line, $throwable);
 
@@ -45,10 +45,10 @@ class ErrorManager
         }
     }
 
-    public function addWarning(string $message, ?string $file = null, ?int $line = null, ?Throwable $throwable = null): void
+    public function warning(string $message, ?string $file = null, ?int $line = null, ?Throwable $throwable = null): void
     {
         if ($this->configuration->isWarningsAsError()) {
-            $this->addError($message, $file, $line, $throwable);
+            $this->error($message, $file, $line, $throwable);
 
             return;
         }
@@ -74,57 +74,8 @@ class ErrorManager
     /**
      * @return list<Error>
      */
-    public function getAllErrors(): array
-    {
-        return $this->errors;
-    }
-
-    /**
-     * @deprecated Use addError() instead
-     */
-    public function error(string $message, ?Throwable $throwable = null): void
-    {
-        $this->errors[] = new Error($message, null, null, $throwable);
-
-        if (! $this->configuration->isSilentOnError()) {
-            echo '/!\\ ' . $message . "\n";
-        }
-
-        if ($this->configuration->isAbortOnError()) {
-            throw new Exception($message, 0, $throwable);
-        }
-    }
-
-    /**
-     * @deprecated Use addWarning() instead
-     */
-    public function warning(string $message): void
-    {
-        if ($this->configuration->isWarningsAsError()) {
-            $this->error($message);
-
-            return;
-        }
-
-        if ($this->configuration->isSilentOnError()) {
-            return;
-        }
-
-        echo $message . "\n";
-    }
-
-    /**
-     * @deprecated use getAllErrors() instead
-     *
-     * @return string[]
-     */
     public function getErrors(): array
     {
-        $outputs = [];
-        foreach ($this->errors as $error) {
-            $outputs[] = $error->asString();
-        }
-
-        return $outputs;
+        return $this->errors;
     }
 }

--- a/lib/Nodes/DocumentNode.php
+++ b/lib/Nodes/DocumentNode.php
@@ -236,11 +236,10 @@ class DocumentNode extends Node
         $currentFileName = $this->environment->getCurrentFileName();
 
         foreach ($this->environment->getInvalidLinks() as $invalidLink) {
-            $this->errorManager->error(sprintf(
-                'Found invalid reference "%s"%s',
-                $invalidLink->getName(),
-                $currentFileName !== '' ? sprintf(' in file "%s"', $currentFileName) : ''
-            ));
+            $this->errorManager->addError(
+                sprintf('Found invalid reference "%s"', $invalidLink->getName()),
+                $currentFileName
+            );
         }
     }
 }

--- a/lib/Nodes/DocumentNode.php
+++ b/lib/Nodes/DocumentNode.php
@@ -236,7 +236,7 @@ class DocumentNode extends Node
         $currentFileName = $this->environment->getCurrentFileName();
 
         foreach ($this->environment->getInvalidLinks() as $invalidLink) {
-            $this->errorManager->addError(
+            $this->errorManager->error(
                 sprintf('Found invalid reference "%s"', $invalidLink->getName()),
                 $currentFileName
             );

--- a/lib/Nodes/TableNode.php
+++ b/lib/Nodes/TableNode.php
@@ -153,7 +153,7 @@ class TableNode extends Node
         if (count($this->errors) > 0) {
             $parser->getEnvironment()
                 ->getErrorManager()
-                ->addError(sprintf("%s\n\n%s", $this->errors[0], $tableAsString), $parser->getFilename());
+                ->error(sprintf("%s\n\n%s", $this->errors[0], $tableAsString), $parser->getFilename());
 
             $this->data    = [];
             $this->headers = [];

--- a/lib/Nodes/TableNode.php
+++ b/lib/Nodes/TableNode.php
@@ -153,7 +153,7 @@ class TableNode extends Node
         if (count($this->errors) > 0) {
             $parser->getEnvironment()
                 ->getErrorManager()
-                ->error(sprintf("%s\nin file %s\n\n%s", $this->errors[0], $parser->getFilename(), $tableAsString));
+                ->addError(sprintf("%s\n\n%s", $this->errors[0], $tableAsString), $parser->getFilename());
 
             $this->data    = [];
             $this->headers = [];

--- a/lib/Parser/DocumentParser.php
+++ b/lib/Parser/DocumentParser.php
@@ -653,7 +653,7 @@ final class DocumentParser
 
         if (! isset($this->directives[$parserDirective->getName()])) {
             $this->environment->getErrorManager()->error(
-                sprintf('Unknown directive "%s": %s', $parserDirective->getName(), $line),
+                sprintf('Unknown directive "%s" for line "%s"', $parserDirective->getName(), $line),
                 $this->environment->getCurrentFileName()
             );
 

--- a/lib/Parser/DocumentParser.php
+++ b/lib/Parser/DocumentParser.php
@@ -318,7 +318,7 @@ final class DocumentParser
             case State::LIST:
                 if (! $this->lineChecker->isListLine($line, $this->listMarker, $this->listOffset) && ! $this->lineChecker->isBlockLine($line, max(1, $this->listOffset))) {
                     if (trim($this->lines->getPreviousLine()) !== '') {
-                        $this->environment->getErrorManager()->addWarning(
+                        $this->environment->getErrorManager()->warning(
                             'List ends without a blank line; unexpected unindent',
                             $this->environment->getCurrentFileName(),
                             $this->currentLineNumber !== null ? $this->currentLineNumber - 1 : null
@@ -455,7 +455,7 @@ final class DocumentParser
                 break;
 
             default:
-                $this->environment->getErrorManager()->addError('Parser ended in an unexcepted state');
+                $this->environment->getErrorManager()->error('Parser ended in an unexcepted state');
         }
 
         return true;
@@ -589,7 +589,7 @@ final class DocumentParser
                         $this->directive->getOptions()
                     );
                 } catch (Throwable $e) {
-                    $this->environment->getErrorManager()->addError(
+                    $this->environment->getErrorManager()->error(
                         sprintf('Error while processing "%s" directive: %s', $currentDirective->getName(), $e->getMessage()),
                         $this->environment->getCurrentFileName(),
                         $this->currentLineNumber ?? null,
@@ -652,7 +652,7 @@ final class DocumentParser
         }
 
         if (! isset($this->directives[$parserDirective->getName()])) {
-            $this->environment->getErrorManager()->addError(
+            $this->environment->getErrorManager()->error(
                 sprintf('Unknown directive "%s": %s', $parserDirective->getName(), $line),
                 $this->environment->getCurrentFileName()
             );

--- a/lib/Parser/DocumentParser.php
+++ b/lib/Parser/DocumentParser.php
@@ -590,7 +590,7 @@ final class DocumentParser
                     );
                 } catch (Throwable $e) {
                     $this->environment->getErrorManager()->error(
-                        sprintf('Error while processing "%s" directive: %s', $currentDirective->getName(), $e->getMessage()),
+                        sprintf('Error while processing "%s" directive: "%s"', $currentDirective->getName(), $e->getMessage()),
                         $this->environment->getCurrentFileName(),
                         $this->currentLineNumber ?? null,
                         $e

--- a/tests/BuilderWithErrors/BuilderWithErrorsTest.php
+++ b/tests/BuilderWithErrors/BuilderWithErrorsTest.php
@@ -32,8 +32,8 @@ EOF
             , $bodyHtml);
 
         self::assertEquals(
-            ['Error while processing "note" directive in "no_content_directive" around line 6: Content expected, none found.'],
-            $this->builder->getErrorManager()->getErrors()
+            'Error while processing "note" directive: "Content expected, none found." in file "no_content_directive" at line 6',
+            $this->builder->getErrorManager()->getErrors()[0]->asString()
         );
     }
 

--- a/tests/EnvironmentTest.php
+++ b/tests/EnvironmentTest.php
@@ -82,7 +82,7 @@ class EnvironmentTest extends TestCase
         ];
 
         yield 'with_current_filename' => [
-            'Unknown reference section "doc" in "current_doc_filename"',
+            'Unknown reference section "doc" in file "current_doc_filename"',
             'current_doc_filename',
         ];
     }

--- a/tests/ErrorManagerTest.php
+++ b/tests/ErrorManagerTest.php
@@ -13,6 +13,9 @@ use function ob_start;
 
 class ErrorManagerTest extends TestCase
 {
+    /**
+     * @group legacy
+     */
     public function testGetErrors(): void
     {
         $configuration = $this->createMock(Configuration::class);
@@ -26,5 +29,46 @@ class ErrorManagerTest extends TestCase
         $errorManager->error('ERROR BAR');
         ob_end_clean();
         self::assertSame(['ERROR FOO', 'ERROR BAR'], $errorManager->getErrors());
+    }
+
+    /**
+     * Make sure the method is unchanged when addError() is used.
+     *
+     * @group legacy
+     */
+    public function testGetErrorsWithNewErrorObject(): void
+    {
+        $configuration = $this->createMock(Configuration::class);
+        $configuration->expects(self::atLeastOnce())
+            ->method('isAbortOnError')
+            ->willReturn(false);
+        $configuration->expects(self::atLeastOnce())
+            ->method('isSilentOnError')
+            ->willReturn(true);
+
+        $errorManager = new ErrorManager($configuration);
+        $errorManager->addError('ERROR FOO');
+        $errorManager->addError('ERROR BAR');
+
+        self::assertSame(['ERROR FOO', 'ERROR BAR'], $errorManager->getErrors());
+    }
+
+    public function testGetAllErrors(): void
+    {
+        $configuration = $this->createMock(Configuration::class);
+        $configuration->expects(self::atLeastOnce())
+            ->method('isAbortOnError')
+            ->willReturn(false);
+        $configuration->expects(self::atLeastOnce())
+            ->method('isSilentOnError')
+            ->willReturn(true);
+
+        $errorManager = new ErrorManager($configuration);
+        $errorManager->addError('ERROR FOO');
+        $errorManager->addError('ERROR BAR');
+
+        $errors = $errorManager->getAllErrors();
+        self::assertSame('ERROR FOO', $errors[0]->asString());
+        self::assertSame('ERROR BAR', $errors[1]->asString());
     }
 }

--- a/tests/ErrorManagerTest.php
+++ b/tests/ErrorManagerTest.php
@@ -8,66 +8,23 @@ use Doctrine\RST\Configuration;
 use Doctrine\RST\ErrorManager;
 use PHPUnit\Framework\TestCase;
 
-use function ob_end_clean;
-use function ob_start;
-
 class ErrorManagerTest extends TestCase
 {
-    /**
-     * @group legacy
-     */
     public function testGetErrors(): void
     {
         $configuration = $this->createMock(Configuration::class);
         $configuration->expects(self::atLeastOnce())
             ->method('isAbortOnError')
             ->willReturn(false);
+        $configuration->expects(self::atLeastOnce())
+            ->method('isSilentOnError')
+            ->willReturn(true);
 
         $errorManager = new ErrorManager($configuration);
-        ob_start();
         $errorManager->error('ERROR FOO');
         $errorManager->error('ERROR BAR');
-        ob_end_clean();
-        self::assertSame(['ERROR FOO', 'ERROR BAR'], $errorManager->getErrors());
-    }
 
-    /**
-     * Make sure the method is unchanged when addError() is used.
-     *
-     * @group legacy
-     */
-    public function testGetErrorsWithNewErrorObject(): void
-    {
-        $configuration = $this->createMock(Configuration::class);
-        $configuration->expects(self::atLeastOnce())
-            ->method('isAbortOnError')
-            ->willReturn(false);
-        $configuration->expects(self::atLeastOnce())
-            ->method('isSilentOnError')
-            ->willReturn(true);
-
-        $errorManager = new ErrorManager($configuration);
-        $errorManager->addError('ERROR FOO');
-        $errorManager->addError('ERROR BAR');
-
-        self::assertSame(['ERROR FOO', 'ERROR BAR'], $errorManager->getErrors());
-    }
-
-    public function testGetAllErrors(): void
-    {
-        $configuration = $this->createMock(Configuration::class);
-        $configuration->expects(self::atLeastOnce())
-            ->method('isAbortOnError')
-            ->willReturn(false);
-        $configuration->expects(self::atLeastOnce())
-            ->method('isSilentOnError')
-            ->willReturn(true);
-
-        $errorManager = new ErrorManager($configuration);
-        $errorManager->addError('ERROR FOO');
-        $errorManager->addError('ERROR BAR');
-
-        $errors = $errorManager->getAllErrors();
+        $errors = $errorManager->getErrors();
         self::assertSame('ERROR FOO', $errors[0]->asString());
         self::assertSame('ERROR BAR', $errors[1]->asString());
     }

--- a/tests/Functional/tests/main-directive/main-directive.html
+++ b/tests/Functional/tests/main-directive/main-directive.html
@@ -1,2 +1,2 @@
 Exception: Exception
-Unknown directive "latex-main": .. latex-main::
+Unknown directive "latex-main" for line ".. latex-main::"

--- a/tests/Functional/tests/main-directive/main-directive.html
+++ b/tests/Functional/tests/main-directive/main-directive.html
@@ -1,2 +1,2 @@
 Exception: Exception
-Unknown directive: "latex-main" for line ".. latex-main::"
+Unknown directive "latex-main": .. latex-main::

--- a/tests/Functional/tests/pretty-table-error1/pretty-table-error1.html
+++ b/tests/Functional/tests/pretty-table-error1/pretty-table-error1.html
@@ -4,7 +4,6 @@ Malformed table: Line
 forgot a blank line
 
 does not appear to be a complete table row
-in file (unknown)
 
 +-----------+----------------+----------------------------+
 | Type      | Options        | Description                |
@@ -13,4 +12,4 @@ in file (unknown)
 +-----------+----------------+----------------------------+
 | currency  | currency (m)   | A currency string          |
 +-----------+----------------+----------------------------+
-forgot a blank line
+forgot a blank line in file "(unknown)"

--- a/tests/Functional/tests/simple-table-error1/simple-table-error1.html
+++ b/tests/Functional/tests/simple-table-error1/simple-table-error1.html
@@ -1,9 +1,8 @@
 Exception: Exception
 Malformed table: content "l" appears in the "gap" on row "Second row  Other colllOther col"
-in file (unknown)
 
 =========== ========== =========
 First col   Second col Third col
 Second row  Other colllOther col
 Third  row  Other col  Last col
-=========== ========== =========
+=========== ========== ========= in file "(unknown)"

--- a/tests/Functional/tests/unknown-directive/unknown-directive.html
+++ b/tests/Functional/tests/unknown-directive/unknown-directive.html
@@ -1,2 +1,2 @@
 Exception: Exception
-Unknown directive "unknown-directive": .. unknown-directive::
+Unknown directive "unknown-directive" for line ".. unknown-directive::"

--- a/tests/Functional/tests/unknown-directive/unknown-directive.html
+++ b/tests/Functional/tests/unknown-directive/unknown-directive.html
@@ -1,2 +1,2 @@
 Exception: Exception
-Unknown directive: "unknown-directive" for line ".. unknown-directive::"
+Unknown directive "unknown-directive": .. unknown-directive::

--- a/tests/Parser/DocumentParserTest.php
+++ b/tests/Parser/DocumentParserTest.php
@@ -7,6 +7,7 @@ namespace Doctrine\Tests\RST\Parser;
 use Doctrine\Common\EventManager;
 use Doctrine\RST\Directives\Directive;
 use Doctrine\RST\Environment;
+use Doctrine\RST\ErrorManager;
 use Doctrine\RST\NodeFactory\NodeFactory;
 use Doctrine\RST\Parser;
 use Doctrine\RST\Parser\DocumentParser;
@@ -22,6 +23,7 @@ class DocumentParserTest extends TestCase
         $nodeFactory        = $this->createMock(NodeFactory::class);
         $eventManager       = $this->createMock(EventManager::class);
         $codeBlockDirective = $this->createMock(Directive::class);
+        $errorManager       = $this->createMock(ErrorManager::class);
 
         $docParser = new DocumentParser(
             $parser,
@@ -41,8 +43,12 @@ class DocumentParserTest extends TestCase
             ->willReturn('code-block-name');
 
         $environment->expects(self::once())
-            ->method('addError')
-            ->with('Error while processing "code-block-name" directive: Invalid something something!');
+            ->method('getErrorManager')
+            ->willReturn($errorManager);
+
+        $errorManager->expects(self::once())
+            ->method('error')
+            ->with('Error while processing "code-block-name" directive: "Invalid something something!"');
 
         $docParser->parse('.. code-block:: php');
     }


### PR DESCRIPTION
The end goal of this PR is to be able to run the parser and output a well formatted error message. I would really like to be able to create good "github actions code comments" (or [commands](https://docs.github.com/en/actions/reference/workflow-commands-for-github-actions#setting-an-error-message)). That is why I need to be able to get the errors in a more structured way. 

This PR does not break BC. 