### PR TITLE
Fix parsing definition list term

### DIFF
--- a/lib/Parser/LineDataParser.php
+++ b/lib/Parser/LineDataParser.php
@@ -11,6 +11,7 @@ use Doctrine\RST\Nodes\SpanNode;
 use Doctrine\RST\Parser;
 
 use function array_map;
+use function array_shift;
 use function count;
 use function explode;
 use function ltrim;
@@ -210,11 +211,8 @@ class LineDataParser
                     $definitionList[] = $createDefinitionTerm($definitionListTerm);
                 }
 
-                $parts = explode(':', trim($line));
-
-                $term = $parts[0];
-                unset($parts[0]);
-
+                $parts       = explode(' : ', trim($line));
+                $term        = array_shift($parts);
                 $classifiers = array_map(function (string $classifier): SpanNode {
                     return $this->parser->createSpanNode($classifier);
                 }, array_map('trim', $parts));

--- a/lib/Templates/default/html/definition-list.html.twig
+++ b/lib/Templates/default/html/definition-list.html.twig
@@ -1,4 +1,3 @@
-{% apply spaceless %}
 <dl{% if definitionListNode.classes %} class="{{ definitionListNode.classesString }}"{% endif %}>
     {% for definitionListTerm in definitionList.terms %}
         {% if definitionListTerm.classifiers is empty %}
@@ -21,4 +20,3 @@
         </dd>
     {% endfor %}
 </dl>
-{% endapply %}

--- a/tests/Functional/tests/definition-list/definition-list.html
+++ b/tests/Functional/tests/definition-list/definition-list.html
@@ -15,22 +15,24 @@
             <p>Definition 2</p>
             <p class="last">Definition 3</p>
         </dd>
-        <dt> term 3 <span class="classifier-delimiter">:</span><span class="classifier">classifier</span></dt>
+        <dt> term 3 <span class="classifier-delimiter">:</span> <span class="classifier">classifier</span> </dt>
         <dd> Definition 1 </dd>
-        <dt> term 4 <span class="classifier-delimiter">:</span><span class="classifier">classifier one</span><span class="classifier-delimiter">:</span><span class="classifier">classifier two</span></dt>
+        <dt> term 4 <span class="classifier-delimiter">:</span> <span class="classifier">classifier one</span> <span class="classifier-delimiter">:</span> <span class="classifier">classifier two</span> </dt>
         <dd> Definition 1 </dd>
-        <dt> term with &amp; <span class="classifier-delimiter">:</span><span class="classifier">classifier with &amp;</span></dt>
+        <dt> term with &amp; <span class="classifier-delimiter">:</span> <span class="classifier">classifier with &amp;</span> </dt>
         <dd> Definition 1 with &amp; </dd>
-        <dt> term with &amp; <span class="classifier-delimiter">:</span><span class="classifier">classifier with &amp;</span><span class="classifier-delimiter">:</span><span class="classifier">classifier with &amp;</span></dt>
+        <dt> term with &amp; <span class="classifier-delimiter">:</span> <span class="classifier">classifier with &amp;</span> <span class="classifier-delimiter">:</span> <span class="classifier">classifier with &amp;</span> </dt>
         <dd>
             <p class="first">Definition 1 with &amp;</p>
             <p class="last">Definition 2 with &amp;</p>
         </dd>
         <dt>
-            <code>term 5</code><span class="classifier-delimiter">:</span>
+            <code>term 5</code> <span class="classifier-delimiter">:</span>
             <span class="classifier"><code>classifier</code></span>
         </dt>
         <dd> Definition 1 </dd>
+        <dt><strong>Complex:</strong> <code>int</code></dt>
+        <dd> Colon must be surrounded by spaces to be a term identifier </dd>
         <dt>multi-line definition term</dt>
         <dd>
             <p class="first">Definition 1 line 1

--- a/tests/Functional/tests/definition-list/definition-list.rst
+++ b/tests/Functional/tests/definition-list/definition-list.rst
@@ -33,6 +33,9 @@ term with & : classifier with & : classifier with &
 ``term 5`` : ``classifier``
     Definition 1
 
+**Complex:** ``int``
+    Colon must be surrounded by spaces to be a term identifier
+
 multi-line definition term
     Definition 1 line 1
     Definition 1 line 2

--- a/tests/Functional/tests/standalone-email-addresses/standalone-email-addresses.html
+++ b/tests/Functional/tests/standalone-email-addresses/standalone-email-addresses.html
@@ -80,7 +80,7 @@ Message-ID: &lt;<a href="mailto:1236@local.machine.example">1236@local.machine.e
 <blockquote>
     <hr />
     <dl>
-        <dt> Received <span class="classifier-delimiter">:</span><span class="classifier">from x.y.test</span></dt>
+        <dt>Received: from x.y.test</dt>
         <dd> by example.net
 via TCP
 with ESMTP


### PR DESCRIPTION
This is catched by @javiereguiluz and reported in https://github.com/symfony-tools/docs-builder/pull/108 The classifier token should be " : " instead of ":".

~Tests are however failing: somehow, a space is lost. Twig renders with the space, but somewhere in the templating logic of this library, we remove the space.. I'm lost on where this happens.~

I also removed `spaceless`. It removes any whitespace between HTML tags, which is not expected for inline HTML tags (it removes any whitespace). In another PR, I'll remove the other usages of `spaceless` (in https://github.com/symfony-tools/docs-builder/pull/80#issuecomment-805878833 it was concluded that this never has the intended effect)