### PR TITLE
Add more optional debugging features

### DIFF
--- a/lib/Builder/ParseQueueProcessor.php
+++ b/lib/Builder/ParseQueueProcessor.php
@@ -15,6 +15,8 @@ use function fwrite;
 use function getenv;
 use function sprintf;
 
+use const STDERR;
+
 class ParseQueueProcessor
 {
     /** @var Kernel */

--- a/lib/Builder/ParseQueueProcessor.php
+++ b/lib/Builder/ParseQueueProcessor.php
@@ -12,6 +12,7 @@ use Doctrine\RST\Parser;
 
 use function filemtime;
 use function getenv;
+use function sprintf;
 
 class ParseQueueProcessor
 {

--- a/lib/Builder/ParseQueueProcessor.php
+++ b/lib/Builder/ParseQueueProcessor.php
@@ -62,6 +62,10 @@ class ParseQueueProcessor
 
     private function processFile(string $file): void
     {
+        if (getenv('SHELL_VERBOSITY') >= 1) {
+            echo "Processing file: $file\n";
+        }
+
         $fileAbsolutePath = $this->buildFileAbsolutePath($file);
 
         $parser = $this->createFileParser($file);

--- a/lib/Builder/ParseQueueProcessor.php
+++ b/lib/Builder/ParseQueueProcessor.php
@@ -11,6 +11,7 @@ use Doctrine\RST\Nodes\DocumentNode;
 use Doctrine\RST\Parser;
 
 use function filemtime;
+use function getenv;
 
 class ParseQueueProcessor
 {
@@ -63,7 +64,7 @@ class ParseQueueProcessor
     private function processFile(string $file): void
     {
         if (getenv('SHELL_VERBOSITY') >= 1) {
-            echo "Processing file: $file\n";
+            echo sprintf("Processing file: %s\n", $file);
         }
 
         $fileAbsolutePath = $this->buildFileAbsolutePath($file);

--- a/lib/Builder/ParseQueueProcessor.php
+++ b/lib/Builder/ParseQueueProcessor.php
@@ -11,6 +11,7 @@ use Doctrine\RST\Nodes\DocumentNode;
 use Doctrine\RST\Parser;
 
 use function filemtime;
+use function fwrite;
 use function getenv;
 use function sprintf;
 
@@ -65,7 +66,7 @@ class ParseQueueProcessor
     private function processFile(string $file): void
     {
         if (getenv('SHELL_VERBOSITY') >= 1) {
-            echo sprintf("Processing file: %s\n", $file);
+            fwrite(STDERR, sprintf("Processing file: %s\n", $file));
         }
 
         $fileAbsolutePath = $this->buildFileAbsolutePath($file);

--- a/lib/Parser.php
+++ b/lib/Parser.php
@@ -14,6 +14,7 @@ use RuntimeException;
 
 use function file_exists;
 use function file_get_contents;
+use function fwrite;
 use function getenv;
 use function sprintf;
 
@@ -187,7 +188,7 @@ class Parser
     public function parseFile(string $file): DocumentNode
     {
         if (getenv('SHELL_VERBOSITY') >= 2) {
-            echo sprintf("Parsing file: %s\n", $file);
+            fwrite(STDERR, sprintf("Parsing file: %s\n", $file));
         }
 
         if (! file_exists($file)) {

--- a/lib/Parser.php
+++ b/lib/Parser.php
@@ -14,6 +14,7 @@ use RuntimeException;
 
 use function file_exists;
 use function file_get_contents;
+use function getenv;
 use function sprintf;
 
 class Parser
@@ -186,7 +187,7 @@ class Parser
     public function parseFile(string $file): DocumentNode
     {
         if (getenv('SHELL_VERBOSITY') >= 2) {
-            echo "Parsing file: $file\n";
+            echo sprintf("Parsing file: %s\n", $file);
         }
 
         if (! file_exists($file)) {

--- a/lib/Parser.php
+++ b/lib/Parser.php
@@ -185,6 +185,10 @@ class Parser
 
     public function parseFile(string $file): DocumentNode
     {
+        if (getenv('SHELL_VERBOSITY') >= 2) {
+            echo "Parsing file: $file\n";
+        }
+
         if (! file_exists($file)) {
             throw new InvalidArgumentException(sprintf('File at path %s does not exist', $file));
         }

--- a/lib/Parser.php
+++ b/lib/Parser.php
@@ -18,6 +18,8 @@ use function fwrite;
 use function getenv;
 use function sprintf;
 
+use const STDERR;
+
 class Parser
 {
     /** @var Configuration */

--- a/lib/Parser/DocumentParser.php
+++ b/lib/Parser/DocumentParser.php
@@ -35,6 +35,8 @@ use function strlen;
 use function substr;
 use function trim;
 
+use const STDERR;
+
 class DocumentParser
 {
     /** @var Parser */

--- a/lib/Parser/DocumentParser.php
+++ b/lib/Parser/DocumentParser.php
@@ -25,6 +25,7 @@ use function array_search;
 use function assert;
 use function chr;
 use function explode;
+use function fwrite;
 use function getenv;
 use function ltrim;
 use function max;
@@ -239,7 +240,7 @@ class DocumentParser
     private function parseLine(string $line): bool
     {
         if (getenv('SHELL_VERBOSITY') >= 3) {
-            echo sprintf("Parsing line: %s\n", $line);
+            fwrite(STDERR, sprintf("Parsing line: %s\n", $line));
         }
 
         switch ($this->state) {

--- a/lib/Parser/DocumentParser.php
+++ b/lib/Parser/DocumentParser.php
@@ -237,6 +237,10 @@ class DocumentParser
      */
     private function parseLine(string $line): bool
     {
+        if (getenv('SHELL_VERBOSITY') >= 3) {
+            echo "Parsing line: $file\n";
+        }
+
         switch ($this->state) {
             case State::BEGIN:
                 if (trim($line) !== '') {

--- a/lib/Parser/DocumentParser.php
+++ b/lib/Parser/DocumentParser.php
@@ -25,6 +25,7 @@ use function array_search;
 use function assert;
 use function chr;
 use function explode;
+use function getenv;
 use function ltrim;
 use function max;
 use function sprintf;
@@ -238,7 +239,7 @@ class DocumentParser
     private function parseLine(string $line): bool
     {
         if (getenv('SHELL_VERBOSITY') >= 3) {
-            echo "Parsing line: $file\n";
+            echo sprintf("Parsing line: %s\n", $line);
         }
 
         switch ($this->state) {


### PR DESCRIPTION
We're going to start using your great parser to build the entire Symfony Docs contents (from 2.0 to 6.0 version, so it's thousands of RST files and hundreds of thousands of lines of contents).

It's working great, but whenever there is an RST syntax problem in our docs, it's very hard to know exactly where or at least the file where it happened. That's why I had to add this in my local fork of `rst-parser` and I've created this PR in case you consider it useful for all.

Now I can run the doc build command with `-v`, `-vv` and `-vvv` to output increasingly more debugging info. Thanks!