### PR TITLE
Explicitly pass secrets to release workflow

### DIFF
--- a/.github/workflows/release-on-milestone-closed.yml
+++ b/.github/workflows/release-on-milestone-closed.yml
@@ -8,4 +8,10 @@ on:
 jobs:
   release:
     name: "Git tag, release & create merge-up PR"
-    uses: "doctrine/.github/.github/workflows/release-on-milestone-closed.yml@1.1.0"
+    uses: "doctrine/.github/.github/workflows/release-on-milestone-closed.yml@1.1.1"
+    secrets:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      GIT_AUTHOR_EMAIL: ${{ secrets.GIT_AUTHOR_EMAIL }}
+      GIT_AUTHOR_NAME: ${{ secrets.GIT_AUTHOR_NAME }}
+      ORGANIZATION_ADMIN_TOKEN: ${{ secrets.ORGANIZATION_ADMIN_TOKEN }}
+      SIGNING_SECRET_KEY: ${{ secrets.SIGNING_SECRET_KEY }}


### PR DESCRIPTION
I am not sure this is going to fix https://github.com/doctrine/rst-parser/runs/3899626444?check_suite_focus=true, but it would make sense not to pass secrets to another workflow by default.