### PR TITLE
Relax the requirement of symfony/translation-contracts dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "symfony/finder": "^4.1 || ^5.0",
         "symfony/polyfill-mbstring": "^1.0",
         "symfony/string": "^5.3",
-        "symfony/translation-contracts": "^1.1",
+        "symfony/translation-contracts": "^1.1 || ^2.0",
         "twig/twig": "^2.9 || ^3.3"
     },
     "require-dev": {


### PR DESCRIPTION
I introduced this dependency myself because it's required by `symfony/string` ... but I made it too restrictive. Without this change we can't use the symfony-tools/doc-builder in a Symfony app because it uses Symfony Translation ^5.3, which in turn requires translation-contracts ^2.0.

I'm sorry for all this noise 😞 