### PR TITLE
Failing test case for references

### DIFF
--- a/lib/Renderers/SpanNodeRenderer.php
+++ b/lib/Renderers/SpanNodeRenderer.php
@@ -168,7 +168,11 @@ abstract class SpanNodeRenderer implements NodeRenderer, SpanRenderer
                 $metaEntry = $this->environment->getMetaEntry();
 
                 if ($metaEntry !== null && $metaEntry->hasTitle($link)) {
-                    $url = $metaEntry->getUrl() . '#' . Environment::slugify($link);
+                    // A strangely-complex way to simply get the current relative URL
+                    // For example, if the current page is "reference/page", then
+                    // this would return "page" so the final URL is href="page#some-anchor".
+                    $currentRelativeUrl = $this->environment->relativeUrl('/' . $metaEntry->getUrl());
+                    $url                = $currentRelativeUrl . '#' . Environment::slugify($link);
                 }
             }
 

--- a/tests/Builder/BuilderTest.php
+++ b/tests/Builder/BuilderTest.php
@@ -400,7 +400,7 @@ class BuilderTest extends BaseBuilderTest
         $contents = $this->getFileContents($this->targetFile('subdir/test.html'));
 
         self::assertStringContainsString(
-            '<a href="subdir/test.html#em">em</a>',
+            '<a href="test.html#em">em</a>',
             $contents
         );
     }

--- a/tests/BuilderReferences/BuilderReferencesTest.php
+++ b/tests/BuilderReferences/BuilderReferencesTest.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\RST\BuilderReferences;
+
+use Doctrine\RST\Builder;
+use Doctrine\Tests\RST\BaseBuilderTest;
+use Gajus\Dindent\Indenter;
+use Symfony\Component\Finder\Finder;
+
+use function rtrim;
+
+class BuilderReferencesTest extends BaseBuilderTest
+{
+    protected function configureBuilder(Builder $builder): void
+    {
+        $builder->getConfiguration()->abortOnError(false);
+        $builder->getConfiguration()->silentOnError();
+    }
+
+    public function test(): void
+    {
+        $indenter = new Indenter();
+
+        foreach (Finder::create()->files()->in($this->targetFile() . '/../expected') as $file) {
+            $target = $this->targetFile($file->getRelativePathname());
+            self::assertFileExists($target);
+            self::assertEquals(rtrim($file->getContents()), rtrim($indenter->indent($this->getFileContents($target))));
+        }
+    }
+
+    protected function getFixturesDirectory(): string
+    {
+        return 'BuilderReferences';
+    }
+}

--- a/tests/BuilderReferences/expected/index.html
+++ b/tests/BuilderReferences/expected/index.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta charset="utf-8" />
+    </head>
+    <body>
+        <div class="section" id="references">
+            <h1>
+                References
+            </h1>
+            <p>Test <a href="reference.html">referencing a document</a></p>
+            <p>Test <a href="reference.html#test_anchor">referencing an anchor in another document</a></p>
+            <p>Test referencing a <a href="index.html#sub-section">Sub section</a> and Some Sub Section (invalid)</p>
+            <div class="section" id="sub-section">
+                <h2>
+                    Sub section
+                </h2>
+            </div>
+        </div>
+    </body>
+</html>

--- a/tests/BuilderReferences/expected/reference/page.html
+++ b/tests/BuilderReferences/expected/reference/page.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta charset="utf-8" />
+    </head>
+    <body>
+        <div class="section" id="reference-page">
+            <h1>
+                Reference Page
+            </h1>
+            <ul>
+                <li><a href="page.html#some-sub-section">Some Sub Section</a></li>
+                <li><a href="page.html#other">Other Sub Section</a></li>
+                <li><a href="page1.html#another-page">Section on another subpage</a></li>
+            </ul>
+            <p>And what about <a href="../reference.html#test_anchor">the test anchor</a>?</p>
+            <div class="section" id="some-sub-section">
+                <h2>
+                    Some Sub Section
+                </h2>
+                <a id="other"></a>
+
+            </div>
+            <div class="section" id="other-sub-section">
+                <h2>
+                    Other Sub Section
+                </h2>
+            </div>
+        </div>
+    </body>
+</html>

--- a/tests/BuilderReferences/input/index.rst
+++ b/tests/BuilderReferences/input/index.rst
@@ -1,0 +1,11 @@
+References
+==========
+
+Test :ref:`referencing a document <reference>`
+
+Test :ref:`referencing an anchor in another document <test_anchor>`
+
+Test referencing a `Sub section`_ and `Some Sub Section`_ (invalid)
+
+Sub section
+-----------

--- a/tests/BuilderReferences/input/reference.rst
+++ b/tests/BuilderReferences/input/reference.rst
@@ -1,0 +1,6 @@
+.. _test_anchor:
+
+Reference
+=========
+
+Test

--- a/tests/BuilderReferences/input/reference/page.rst
+++ b/tests/BuilderReferences/input/reference/page.rst
@@ -1,0 +1,16 @@
+Reference Page
+==============
+
+* `Some Sub Section`_
+* :ref:`Other Sub Section <other>`
+* :ref:`Section on another subpage <another-page>`
+
+And what about :ref:`the test anchor <test_anchor>`?
+
+Some Sub Section
+----------------
+
+.. _other:
+
+Other Sub Section
+-----------------

--- a/tests/BuilderReferences/input/reference/page1.rst
+++ b/tests/BuilderReferences/input/reference/page1.rst
@@ -1,0 +1,7 @@
+Reference Page 1
+================
+
+.. _another-page:
+
+Section on Another Page
+-----------------------


### PR DESCRIPTION
This adds a failing test for a bug we are experiencing on symfony.com: In articles inside a directory, the implicit references (`` `Some Headline within This Page`_ ``) generate a wrong relative URL (it's relative to the root directory, not the current file).

`` :ref:`... <some-ref>` `` works like expected.