### PR TITLE
Fixing indentation stripped (affect diff highlighting)

### DIFF
--- a/lib/Nodes/Node.php
+++ b/lib/Nodes/Node.php
@@ -15,6 +15,7 @@ use Doctrine\RST\Renderers\NodeRendererFactory;
 use Doctrine\RST\Renderers\RenderedNode;
 
 use function implode;
+use function ltrim;
 use function strlen;
 use function substr;
 use function trim;
@@ -137,18 +138,25 @@ abstract class Node
     protected function normalizeLines(array $lines): string
     {
         if ($lines !== []) {
-            $firstLine = $lines[0];
+            $indentLevel = null;
 
-            $k = 0;
-
-            for ($k = 0; $k < strlen($firstLine); $k++) {
-                if (trim($firstLine[$k]) !== '') {
-                    break;
+            // find the indentation by locating the line with the fewest preceding whitespace
+            foreach ($lines as $line) {
+                // skip empty lines
+                if (trim($line) === '') {
+                    continue;
                 }
+
+                $startingWhitespace = strlen($line) - strlen(ltrim($line));
+                if ($indentLevel !== null && $startingWhitespace > $indentLevel) {
+                    continue;
+                }
+
+                $indentLevel = $startingWhitespace;
             }
 
             foreach ($lines as &$line) {
-                $line = substr($line, $k);
+                $line = substr($line, $indentLevel);
             }
         }
 

--- a/tests/Functional/FunctionalTest.php
+++ b/tests/Functional/FunctionalTest.php
@@ -32,6 +32,7 @@ use const LC_ALL;
 class FunctionalTest extends TestCase
 {
     private const RENDER_DOCUMENT_FILES = ['main-directive'];
+    private const SKIP_INDENTER_FILES   = ['code-block-diff'];
 
     protected function setUp(): void
     {
@@ -47,7 +48,8 @@ class FunctionalTest extends TestCase
         string $renderMethod,
         string $format,
         string $rst,
-        string $expected
+        string $expected,
+        bool $useIndenter = true
     ): void {
         $expectedLines = explode("\n", $expected);
         $firstLine     = $expectedLines[0];
@@ -68,7 +70,7 @@ class FunctionalTest extends TestCase
 
         $rendered = $document->$renderMethod();
 
-        if ($format === Format::HTML) {
+        if ($format === Format::HTML && $useIndenter) {
             $indenter = new Indenter();
             $rendered = $indenter->indent($rendered);
         }
@@ -133,7 +135,9 @@ class FunctionalTest extends TestCase
                     ? 'renderDocument'
                     : 'render';
 
-                $tests[$basename . '_' . $format] = [$basename, $parser, $renderMethod, $format, $rst, trim($expected)];
+                $useIndenter = ! in_array($basename, self::SKIP_INDENTER_FILES, true);
+
+                $tests[$basename . '_' . $format] = [$basename, $parser, $renderMethod, $format, $rst, trim($expected), $useIndenter];
             }
         }
 

--- a/tests/Functional/tests/code-block-diff/code-block-diff.html
+++ b/tests/Functional/tests/code-block-diff/code-block-diff.html
@@ -1,0 +1,14 @@
+<pre><code class="diff">+ Added line
+- Removed line
+  Normal line
+- Removed line
++ Added line
+
+</code></pre>
+<pre><code class="diff">  Normal line
++ Added line
+- Removed line
+  Normal line
+- Removed line
++ Added line
+</code></pre>

--- a/tests/Functional/tests/code-block-diff/code-block-diff.rst
+++ b/tests/Functional/tests/code-block-diff/code-block-diff.rst
@@ -1,0 +1,18 @@
+
+.. code-block:: diff
+
+    + Added line
+    - Removed line
+      Normal line
+    - Removed line
+    + Added line
+
+
+.. code-block:: diff
+
+      Normal line
+    + Added line
+    - Removed line
+      Normal line
+    - Removed line
+    + Added line


### PR DESCRIPTION
Hi!

This fixes https://github.com/symfony-tools/docs-builder/pull/124

tl;dr. Suppose you have

```
code-block: diff

      Normal Line
    + Added line
```

The code-block indentation is really 4 spaces. But because that first line (`Normal Line`) is indented by 6 spaces (2 of which should be part of the code block), the `Node` class currently thinks that the code block is indented by 6 spaces. It then strips the first 6 characters off each line, which strips the `+ ` in front of `+ Added line`.

Cheers!