### PR TITLE
Improve the way debug messages are output to STDERR

### DIFF
--- a/lib/Builder/ParseQueueProcessor.php
+++ b/lib/Builder/ParseQueueProcessor.php
@@ -66,8 +66,11 @@ final class ParseQueueProcessor
 
     private function processFile(string $file): void
     {
-        if (getenv('SHELL_VERBOSITY') >= 1 && $stdErr = fopen('php://stderr', 'wb')) {
-            fwrite($stdErr, sprintf("Processing file: %s\n", $file));
+        if (getenv('SHELL_VERBOSITY') >= 1) {
+            $stdErr = fopen('php://stderr', 'wb');
+            if (false !== $stdErr) {
+                fwrite($stdErr, sprintf("Processing file: %s\n", $file));
+            }
         }
 
         $fileAbsolutePath = $this->buildFileAbsolutePath($file);

--- a/lib/Builder/ParseQueueProcessor.php
+++ b/lib/Builder/ParseQueueProcessor.php
@@ -11,6 +11,7 @@ use Doctrine\RST\Nodes\DocumentNode;
 use Doctrine\RST\Parser;
 
 use function filemtime;
+use function fopen;
 use function fwrite;
 use function getenv;
 use function sprintf;

--- a/lib/Builder/ParseQueueProcessor.php
+++ b/lib/Builder/ParseQueueProcessor.php
@@ -66,8 +66,8 @@ final class ParseQueueProcessor
 
     private function processFile(string $file): void
     {
-        if (getenv('SHELL_VERBOSITY') >= 1) {
-            fwrite(fopen('php://stderr', 'wb'), sprintf("Processing file: %s\n", $file));
+        if (getenv('SHELL_VERBOSITY') >= 1 && $stdErr = fopen('php://stderr', 'wb')) {
+            fwrite($stdErr, sprintf("Processing file: %s\n", $file));
         }
 
         $fileAbsolutePath = $this->buildFileAbsolutePath($file);

--- a/lib/Builder/ParseQueueProcessor.php
+++ b/lib/Builder/ParseQueueProcessor.php
@@ -15,8 +15,6 @@ use function fwrite;
 use function getenv;
 use function sprintf;
 
-use const STDERR;
-
 final class ParseQueueProcessor
 {
     /** @var Kernel */
@@ -68,7 +66,7 @@ final class ParseQueueProcessor
     private function processFile(string $file): void
     {
         if (getenv('SHELL_VERBOSITY') >= 1) {
-            fwrite(STDERR, sprintf("Processing file: %s\n", $file));
+            fwrite(fopen('php://stderr', 'wb'), sprintf("Processing file: %s\n", $file));
         }
 
         $fileAbsolutePath = $this->buildFileAbsolutePath($file);

--- a/lib/Builder/ParseQueueProcessor.php
+++ b/lib/Builder/ParseQueueProcessor.php
@@ -11,10 +11,12 @@ use Doctrine\RST\Nodes\DocumentNode;
 use Doctrine\RST\Parser;
 
 use function filemtime;
-use function fopen;
 use function fwrite;
 use function getenv;
 use function sprintf;
+
+use const PHP_SAPI;
+use const STDERR;
 
 final class ParseQueueProcessor
 {
@@ -66,11 +68,8 @@ final class ParseQueueProcessor
 
     private function processFile(string $file): void
     {
-        if (getenv('SHELL_VERBOSITY') >= 1) {
-            $stdErr = fopen('php://stderr', 'wb');
-            if ($stdErr !== false) {
-                fwrite($stdErr, sprintf("Processing file: %s\n", $file));
-            }
+        if (getenv('SHELL_VERBOSITY') >= 1 && PHP_SAPI === 'cli') {
+            fwrite(STDERR, sprintf("Processing file: %s\n", $file));
         }
 
         $fileAbsolutePath = $this->buildFileAbsolutePath($file);

--- a/lib/Builder/ParseQueueProcessor.php
+++ b/lib/Builder/ParseQueueProcessor.php
@@ -68,7 +68,7 @@ final class ParseQueueProcessor
     {
         if (getenv('SHELL_VERBOSITY') >= 1) {
             $stdErr = fopen('php://stderr', 'wb');
-            if (false !== $stdErr) {
+            if ($stdErr !== false) {
                 fwrite($stdErr, sprintf("Processing file: %s\n", $file));
             }
         }

--- a/lib/Parser.php
+++ b/lib/Parser.php
@@ -14,6 +14,7 @@ use RuntimeException;
 
 use function file_exists;
 use function file_get_contents;
+use function fopen;
 use function fwrite;
 use function getenv;
 use function sprintf;

--- a/lib/Parser.php
+++ b/lib/Parser.php
@@ -190,7 +190,7 @@ class Parser
     {
         if (getenv('SHELL_VERBOSITY') >= 2) {
             $stdErr = fopen('php://stderr', 'wb');
-            if (false !== $stdErr) {
+            if ($stdErr !== false) {
                 fwrite($stdErr, sprintf("Parsing file: %s\n", $file));
             }
         }

--- a/lib/Parser.php
+++ b/lib/Parser.php
@@ -188,8 +188,8 @@ class Parser
 
     public function parseFile(string $file): DocumentNode
     {
-        if (getenv('SHELL_VERBOSITY') >= 2) {
-            fwrite(fopen('php://stderr', 'wb'), sprintf("Parsing file: %s\n", $file));
+        if (getenv('SHELL_VERBOSITY') >= 2 && $stdErr = fopen('php://stderr', 'wb')) {
+            fwrite($stdErr, sprintf("Parsing file: %s\n", $file));
         }
 
         if (! file_exists($file)) {

--- a/lib/Parser.php
+++ b/lib/Parser.php
@@ -18,8 +18,6 @@ use function fwrite;
 use function getenv;
 use function sprintf;
 
-use const STDERR;
-
 class Parser
 {
     /** @var Configuration */
@@ -190,7 +188,7 @@ class Parser
     public function parseFile(string $file): DocumentNode
     {
         if (getenv('SHELL_VERBOSITY') >= 2) {
-            fwrite(STDERR, sprintf("Parsing file: %s\n", $file));
+            fwrite(fopen('php://stderr', 'wb'), sprintf("Parsing file: %s\n", $file));
         }
 
         if (! file_exists($file)) {

--- a/lib/Parser.php
+++ b/lib/Parser.php
@@ -188,8 +188,11 @@ class Parser
 
     public function parseFile(string $file): DocumentNode
     {
-        if (getenv('SHELL_VERBOSITY') >= 2 && $stdErr = fopen('php://stderr', 'wb')) {
-            fwrite($stdErr, sprintf("Parsing file: %s\n", $file));
+        if (getenv('SHELL_VERBOSITY') >= 2) {
+            $stdErr = fopen('php://stderr', 'wb');
+            if (false !== $stdErr) {
+                fwrite($stdErr, sprintf("Parsing file: %s\n", $file));
+            }
         }
 
         if (! file_exists($file)) {

--- a/lib/Parser.php
+++ b/lib/Parser.php
@@ -14,10 +14,12 @@ use RuntimeException;
 
 use function file_exists;
 use function file_get_contents;
-use function fopen;
 use function fwrite;
 use function getenv;
 use function sprintf;
+
+use const PHP_SAPI;
+use const STDERR;
 
 class Parser
 {
@@ -188,11 +190,8 @@ class Parser
 
     public function parseFile(string $file): DocumentNode
     {
-        if (getenv('SHELL_VERBOSITY') >= 2) {
-            $stdErr = fopen('php://stderr', 'wb');
-            if ($stdErr !== false) {
-                fwrite($stdErr, sprintf("Parsing file: %s\n", $file));
-            }
+        if (getenv('SHELL_VERBOSITY') >= 2 && PHP_SAPI === 'cli') {
+            fwrite(STDERR, sprintf("Parsing file: %s\n", $file));
         }
 
         if (! file_exists($file)) {

--- a/lib/Parser/DocumentParser.php
+++ b/lib/Parser/DocumentParser.php
@@ -25,7 +25,6 @@ use function array_search;
 use function assert;
 use function chr;
 use function explode;
-use function fopen;
 use function fwrite;
 use function getenv;
 use function ltrim;
@@ -35,6 +34,9 @@ use function str_replace;
 use function strlen;
 use function substr;
 use function trim;
+
+use const PHP_SAPI;
+use const STDERR;
 
 final class DocumentParser
 {
@@ -240,11 +242,8 @@ final class DocumentParser
      */
     private function parseLine(string $line): bool
     {
-        if (getenv('SHELL_VERBOSITY') >= 3) {
-            $stdErr = fopen('php://stderr', 'wb');
-            if ($stdErr !== false) {
-                fwrite($stdErr, sprintf("Parsing line: %s\n", $line));
-            }
+        if (getenv('SHELL_VERBOSITY') >= 3 && PHP_SAPI === 'cli') {
+            fwrite(STDERR, sprintf("Parsing line: %s\n", $line));
         }
 
         switch ($this->state) {

--- a/lib/Parser/DocumentParser.php
+++ b/lib/Parser/DocumentParser.php
@@ -240,8 +240,8 @@ final class DocumentParser
      */
     private function parseLine(string $line): bool
     {
-        if (getenv('SHELL_VERBOSITY') >= 3) {
-            fwrite(fopen('php://stderr', 'wb'), sprintf("Parsing line: %s\n", $line));
+        if (getenv('SHELL_VERBOSITY') >= 3 && $stdErr = fopen('php://stderr', 'wb')) {
+            fwrite($stdErr, sprintf("Parsing line: %s\n", $line));
         }
 
         switch ($this->state) {

--- a/lib/Parser/DocumentParser.php
+++ b/lib/Parser/DocumentParser.php
@@ -25,6 +25,7 @@ use function array_search;
 use function assert;
 use function chr;
 use function explode;
+use function fopen;
 use function fwrite;
 use function getenv;
 use function ltrim;

--- a/lib/Parser/DocumentParser.php
+++ b/lib/Parser/DocumentParser.php
@@ -240,8 +240,11 @@ final class DocumentParser
      */
     private function parseLine(string $line): bool
     {
-        if (getenv('SHELL_VERBOSITY') >= 3 && $stdErr = fopen('php://stderr', 'wb')) {
-            fwrite($stdErr, sprintf("Parsing line: %s\n", $line));
+        if (getenv('SHELL_VERBOSITY') >= 3) {
+            $stdErr = fopen('php://stderr', 'wb');
+            if (false !== $stdErr) {
+                fwrite($stdErr, sprintf("Parsing line: %s\n", $line));
+            }
         }
 
         switch ($this->state) {

--- a/lib/Parser/DocumentParser.php
+++ b/lib/Parser/DocumentParser.php
@@ -35,8 +35,6 @@ use function strlen;
 use function substr;
 use function trim;
 
-use const STDERR;
-
 final class DocumentParser
 {
     /** @var Parser */
@@ -242,7 +240,7 @@ final class DocumentParser
     private function parseLine(string $line): bool
     {
         if (getenv('SHELL_VERBOSITY') >= 3) {
-            fwrite(STDERR, sprintf("Parsing line: %s\n", $line));
+            fwrite(fopen('php://stderr', 'wb'), sprintf("Parsing line: %s\n", $line));
         }
 
         switch ($this->state) {

--- a/lib/Parser/DocumentParser.php
+++ b/lib/Parser/DocumentParser.php
@@ -242,7 +242,7 @@ final class DocumentParser
     {
         if (getenv('SHELL_VERBOSITY') >= 3) {
             $stdErr = fopen('php://stderr', 'wb');
-            if (false !== $stdErr) {
+            if ($stdErr !== false) {
                 fwrite($stdErr, sprintf("Parsing line: %s\n", $line));
             }
         }


### PR DESCRIPTION
I'm seeing this error occasionally on my local machine:

![](https://user-images.githubusercontent.com/73419/140950916-5249407f-02ed-4ae6-9d03-63704d892e9a.png)

In case others are suffering from this too, I think we could improve code to not rely on this `STDERR` constant.