### PR TITLE
Fix duplicate implicit references with the same id

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,3 +1,11 @@
+# Upgrade to 0.6
+
+## TitleNode requires an id
+
+The TitleNode constructor is changed to require an ID as 4th argument.
+Similarly, `Doctrine\RST\NodeFactory::createTitleNode()` has been
+updated with an ID as 4th argument.
+
 # Upgrade to 0.5
 
 ## Property visibility changed from protected to private

--- a/lib/NodeFactory/DefaultNodeFactory.php
+++ b/lib/NodeFactory/DefaultNodeFactory.php
@@ -78,9 +78,9 @@ final class DefaultNodeFactory implements NodeFactory
         return $tocNode;
     }
 
-    public function createTitleNode(Node $value, int $level, string $token): TitleNode
+    public function createTitleNode(Node $value, int $level, string $token, string $id): TitleNode
     {
-        $titleNode = $this->create(NodeTypes::TITLE, [$value, $level, $token]);
+        $titleNode = $this->create(NodeTypes::TITLE, [$value, $level, $token, $id]);
         assert($titleNode instanceof TitleNode);
 
         return $titleNode;

--- a/lib/NodeFactory/NodeFactory.php
+++ b/lib/NodeFactory/NodeFactory.php
@@ -45,7 +45,7 @@ interface NodeFactory
      */
     public function createTocNode(Environment $environment, array $files, array $options): TocNode;
 
-    public function createTitleNode(Node $value, int $level, string $token): TitleNode;
+    public function createTitleNode(Node $value, int $level, string $token, string $id): TitleNode;
 
     public function createSeparatorNode(int $level): SeparatorNode;
 

--- a/lib/Nodes/DocumentNode.php
+++ b/lib/Nodes/DocumentNode.php
@@ -13,6 +13,7 @@ use Exception;
 use function array_unshift;
 use function assert;
 use function count;
+use function in_array;
 use function is_string;
 use function sprintf;
 
@@ -32,6 +33,9 @@ class DocumentNode extends Node
 
     /** @var Node[] */
     private $nodes = [];
+
+    /** @var string[] */
+    private $implicitLinkTargets = [];
 
     public function __construct(Environment $environment)
     {
@@ -89,6 +93,24 @@ class DocumentNode extends Node
         }
 
         return $nodes;
+    }
+
+    /**
+     * Creates an implicit hyperlink target for this document.
+     *
+     * @param string $preferredId The preferred ID of the hyperlink target, the actual ID is returned by the method (this avoids duplicates)
+     */
+    public function createImplicitLinkTarget(string $preferredId): string
+    {
+        $i        = 1;
+        $actualId = $preferredId;
+        while (in_array($actualId, $this->implicitLinkTargets, true)) {
+            $actualId = $preferredId . '-' . ($i++);
+        }
+
+        $this->implicitLinkTargets[] = $actualId;
+
+        return $actualId;
     }
 
     public function getTitle(): ?string

--- a/lib/Nodes/TitleNode.php
+++ b/lib/Nodes/TitleNode.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace Doctrine\RST\Nodes;
 
-use Doctrine\RST\Environment;
-
 class TitleNode extends Node
 {
     /** @var SpanNode */
@@ -23,13 +21,13 @@ class TitleNode extends Node
     /** @var string */
     private $target = '';
 
-    public function __construct(Node $value, int $level, string $token)
+    public function __construct(Node $value, int $level, string $token, string $id)
     {
         parent::__construct($value);
 
         $this->level = $level;
         $this->token = $token;
-        $this->id    = Environment::slugify($this->value->getText());
+        $this->id    = $id;
     }
 
     public function getValue(): SpanNode

--- a/lib/Parser/DocumentParser.php
+++ b/lib/Parser/DocumentParser.php
@@ -490,11 +490,13 @@ final class DocumentParser
                     $level = $this->environment->getConfiguration()->getInitialHeaderLevel() + $level - 1;
 
                     $token = $this->environment->createTitle($level);
+                    $id    = $this->document->createImplicitLinkTarget(Environment::slugify($data));
 
                     $node = $this->nodeFactory->createTitleNode(
                         $this->parser->createSpanNode($data),
                         $level,
-                        $token
+                        $token,
+                        $id
                     );
 
                     if ($this->lastTitleNode !== null) {

--- a/tests/DefaultNodeFactoryTest.php
+++ b/tests/DefaultNodeFactoryTest.php
@@ -92,12 +92,12 @@ class DefaultNodeFactoryTest extends TestCase
 
         $nodeInstantiator->expects(self::once())
             ->method('create')
-            ->with([$node, 1, 'test'])
+            ->with([$node, 1, 'test', 'test'])
             ->willReturn($expectedReturn);
 
         $defaultNodeFactory = $this->createDefaultNodeFactory($nodeInstantiator);
 
-        self::assertSame($expectedReturn, $defaultNodeFactory->createTitleNode($node, 1, 'test'));
+        self::assertSame($expectedReturn, $defaultNodeFactory->createTitleNode($node, 1, 'test', 'test'));
     }
 
     public function testCreateSeparator(): void

--- a/tests/Functional/tests/section-nesting/section-nesting.html
+++ b/tests/Functional/tests/section-nesting/section-nesting.html
@@ -37,7 +37,7 @@
     <h1>
         Level 1 Test 4
     </h1>
-    <div class="section" id="level-2-test-3">
+    <div class="section" id="level-2-test-3-1">
         <h2>
             Level 2 Test 3
         </h2>

--- a/tests/Functional/tests/titles/titles.html
+++ b/tests/Functional/tests/titles/titles.html
@@ -40,6 +40,11 @@
         <h2>
             em
         </h2>
+        <div class="section" id="first-subtitle-1">
+            <h3>
+                First subtitle
+            </h3>
+        </div>
     </div>
 </div>
 <div class="section" id="second-main-title">

--- a/tests/Functional/tests/titles/titles.rst
+++ b/tests/Functional/tests/titles/titles.rst
@@ -30,6 +30,9 @@ Fourth subsubtitle
 em
 --
 
+First subtitle
+~~~~~~~~~~~~~~
+
 Second Main Title
 =================
 

--- a/tests/Functional/tests/titles/titles.tex
+++ b/tests/Functional/tests/titles/titles.tex
@@ -24,6 +24,9 @@ Text again
 
 \section{em}
 
+\subsection{First subtitle}
+
+
 
 
 \chapter{Second Main Title}


### PR DESCRIPTION
This fixes a common bug in the docs (it has been reported multiple times over the past couple weeks).

If two or more titles on the same page have the same name, the references to the sections is wrong (as the ID is duplicate, you can never link to the second section).

Sphinx/docutils solve this by replacing any duplicate internal references with `id1`, `id2`, etc. I suggest making things a bit nicer by adding `-1`, `-2`, ... to the actual reference ID instead.

For reference, docutils actually manages references using a node visitor pattern. We've discussed adding something like this before (#145), but with the ongoing development on PHPdocumentor's side, I'm trying to keep the changes to this library to a minimal.