### PR TITLE
Rename "links" to "link targets"

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,3 +1,18 @@
+# Upgrade to 0.6
+
+## Renamed links to link targets
+
+The library has been updated to use "link target" instead of "link":
+
+* Renamed `Environment::setLink()`, `Environment::getLink()` and
+  `Environment::getLinks()` to `Environment::setLinkTarget()`,
+  `Environment::getLinkTarget()` and `Environment::getLinkTargets()`
+* Renamed `Metas::findLinkMetaEntry()` and `Metas::doesLinkExist()` to
+  `Metas::findLinkTargetMetaEntry()` and `Metas::doesLinkTargetExist()`.
+* Renamed `DocumentParser::parseLink()` to `DocumentParser::parseLinkTarget()`.
+* Renamed `LineDataParser::parseLink()` and `LineDataParser::createLink()` to
+  `LineDataParser::parseLinkTarget()` and `LineDataParser::createLinkTarget()`.
+
 # Upgrade to 0.5
 
 ## Property visibility changed from protected to private

--- a/lib/Builder/ParseQueueProcessor.php
+++ b/lib/Builder/ParseQueueProcessor.php
@@ -92,7 +92,7 @@ final class ParseQueueProcessor
             $document->getTocs(),
             (int) filemtime($fileAbsolutePath),
             $environment->getDependencies(),
-            $environment->getLinks()
+            $environment->getLinkTargets()
         );
     }
 

--- a/lib/Environment.php
+++ b/lib/Environment.php
@@ -69,7 +69,7 @@ class Environment
     private $variables = [];
 
     /** @var string[] */
-    private $links = [];
+    private $linkTargets = [];
 
     /** @var int[] */
     private $levels = [];
@@ -259,7 +259,13 @@ class Environment
         return $default;
     }
 
-    public function setLink(string $name, string $url): void
+    /**
+     * Adds a link target to the environment.
+     *
+     * https://docutils.sourceforge.io/docs/ref/rst/restructuredtext.html#explicit-hyperlink-targets
+     * https://docutils.sourceforge.io/docs/ref/rst/restructuredtext.html#implicit-hyperlink-targets
+     */
+    public function setLinkTarget(string $name, string $url): void
     {
         $name = trim(strtolower($name));
 
@@ -267,7 +273,7 @@ class Environment
             $name = array_shift($this->anonymous);
         }
 
-        $this->links[$name] = trim($url);
+        $this->linkTargets[$name] = trim($url);
     }
 
     public function resetAnonymousStack(): void
@@ -283,17 +289,17 @@ class Environment
     /**
      * @return string[]
      */
-    public function getLinks(): array
+    public function getLinkTargets(): array
     {
-        return $this->links;
+        return $this->linkTargets;
     }
 
-    public function getLink(string $name, bool $relative = true): string
+    public function getLinkTarget(string $name, bool $relative = true): string
     {
         $name = trim(strtolower($name));
 
-        if (isset($this->links[$name])) {
-            $link = $this->links[$name];
+        if (isset($this->linkTargets[$name])) {
+            $link = $this->linkTargets[$name];
 
             if ($relative) {
                 return (string) $this->relativeUrl($link);

--- a/lib/HTML/Renderers/SpanNodeRenderer.php
+++ b/lib/HTML/Renderers/SpanNodeRenderer.php
@@ -92,7 +92,7 @@ final class SpanNodeRenderer extends BaseSpanNodeRenderer
 
         // reference to anchor in existing document
         } elseif ($value['url'] !== null) {
-            $url = $this->environment->getLink($value['url']);
+            $url = $this->environment->getLinkTarget($value['url']);
 
             $link = $this->link($url, $text, $reference->getAttributes());
         } else {

--- a/lib/Meta/MetaEntry.php
+++ b/lib/Meta/MetaEntry.php
@@ -41,7 +41,7 @@ class MetaEntry
     private $resolvedDependencies = [];
 
     /** @var string[] */
-    private $links;
+    private $linkTargets;
 
     /** @var string|null */
     private $parent;
@@ -50,7 +50,7 @@ class MetaEntry
      * @param string[][]|string[][][] $titles
      * @param mixed[][]               $tocs
      * @param string[]                $depends
-     * @param string[]                $links
+     * @param string[]                $linkTargets
      */
     public function __construct(
         string $file,
@@ -59,17 +59,17 @@ class MetaEntry
         array $titles,
         array $tocs,
         array $depends,
-        array $links,
+        array $linkTargets,
         int $mtime
     ) {
-        $this->file    = $file;
-        $this->url     = $url;
-        $this->title   = $title;
-        $this->titles  = $titles;
-        $this->tocs    = $tocs;
-        $this->depends = $depends;
-        $this->links   = $links;
-        $this->mtime   = $mtime;
+        $this->file        = $file;
+        $this->url         = $url;
+        $this->title       = $title;
+        $this->titles      = $titles;
+        $this->tocs        = $tocs;
+        $this->depends     = $depends;
+        $this->linkTargets = $linkTargets;
+        $this->mtime       = $mtime;
     }
 
     public function getFile(): string
@@ -164,9 +164,9 @@ class MetaEntry
     /**
      * @return string[]
      */
-    public function getLinks(): array
+    public function getLinkTargets(): array
     {
-        return $this->links;
+        return $this->linkTargets;
     }
 
     public function getMtime(): int

--- a/lib/Meta/Metas.php
+++ b/lib/Meta/Metas.php
@@ -24,15 +24,15 @@ class Metas
         $this->entries = $entries;
     }
 
-    public function findLinkMetaEntry(string $link): ?MetaEntry
+    public function findLinkTargetMetaEntry(string $linkTarget): ?MetaEntry
     {
         foreach ($this->entries as $entry) {
-            if ($this->doesLinkExist($entry->getLinks(), $link)) {
+            if ($this->doesLinkTargetExist($entry->getLinkTargets(), $linkTarget)) {
                 return $entry;
             }
         }
 
-        return $this->findByTitle($link);
+        return $this->findByTitle($linkTarget);
     }
 
     /**
@@ -47,7 +47,7 @@ class Metas
      * @param string[][] $titles
      * @param mixed[][]  $tocs
      * @param string[]   $depends
-     * @param string[]   $links
+     * @param string[]   $linkTargets
      */
     public function set(
         string $file,
@@ -57,7 +57,7 @@ class Metas
         array $tocs,
         int $mtime,
         array $depends,
-        array $links
+        array $linkTargets
     ): void {
         foreach ($tocs as $toc) {
             foreach ($toc as $child) {
@@ -78,7 +78,7 @@ class Metas
             $titles,
             $tocs,
             $depends,
-            $links,
+            $linkTargets,
             $mtime
         );
 
@@ -107,12 +107,12 @@ class Metas
     }
 
     /**
-     * @param string[] $links
+     * @param string[] $linkTargets
      */
-    private function doesLinkExist(array $links, string $link): bool
+    private function doesLinkTargetExist(array $linkTargets, string $target): bool
     {
-        foreach ($links as $name => $url) {
-            if ($name === strtolower($link)) {
+        foreach ($linkTargets as $name => $url) {
+            if ($name === strtolower($target)) {
                 return true;
             }
         }

--- a/lib/Parser/DocumentParser.php
+++ b/lib/Parser/DocumentParser.php
@@ -276,7 +276,7 @@ final class DocumentParser
                         return false;
                     }
 
-                    if ($this->parseLink($line)) {
+                    if ($this->parseLinkTarget($line)) {
                         return true;
                     }
 
@@ -714,9 +714,9 @@ final class DocumentParser
         return false;
     }
 
-    private function parseLink(string $line): bool
+    private function parseLinkTarget(string $line): bool
     {
-        $link = $this->lineDataParser->parseLink($line);
+        $link = $this->lineDataParser->parseLinkTarget($line);
 
         if ($link === null) {
             return false;
@@ -729,7 +729,7 @@ final class DocumentParser
             $this->document->addNode($anchorNode);
         }
 
-        $this->environment->setLink($link->getName(), $link->getUrl());
+        $this->environment->setLinkTarget($link->getName(), $link->getUrl());
 
         return true;
     }

--- a/lib/Parser/LineDataParser.php
+++ b/lib/Parser/LineDataParser.php
@@ -35,23 +35,23 @@ final class LineDataParser
         $this->eventManager = $eventManager;
     }
 
-    public function parseLink(string $line): ?Link
+    public function parseLinkTarget(string $line): ?Link
     {
         // Links
         if (preg_match('/^\.\. _`(.+)`: (.+)$/mUsi', $line, $match) > 0) {
-            return $this->createLink($match[1], $match[2], Link::TYPE_LINK);
+            return $this->createLinkTarget($match[1], $match[2], Link::TYPE_LINK);
         }
 
         // anonymous links
         if (preg_match('/^\.\. _(.+): (.+)$/mUsi', $line, $match) > 0) {
-            return $this->createLink($match[1], $match[2], Link::TYPE_LINK);
+            return $this->createLinkTarget($match[1], $match[2], Link::TYPE_LINK);
         }
 
         // Short anonymous links
         if (preg_match('/^__ (.+)$/mUsi', trim($line), $match) > 0) {
             $url = $match[1];
 
-            return $this->createLink('_', $url, Link::TYPE_LINK);
+            return $this->createLinkTarget('_', $url, Link::TYPE_LINK);
         }
 
         // Anchor links - ".. _`anchor-link`:"
@@ -64,13 +64,13 @@ final class LineDataParser
         if (preg_match('/^\.\. _(.+):$/mUsi', trim($line), $match) > 0) {
             $anchor = $match[1];
 
-            return $this->createLink($anchor, '#' . $anchor, Link::TYPE_ANCHOR);
+            return $this->createLinkTarget($anchor, '#' . $anchor, Link::TYPE_ANCHOR);
         }
 
         return null;
     }
 
-    private function createLink(string $name, string $url, string $type): Link
+    private function createLinkTarget(string $name, string $url, string $type): Link
     {
         $this->eventManager->dispatchEvent(
             OnLinkParsedEvent::ON_LINK_PARSED,

--- a/lib/Parser/Link.php
+++ b/lib/Parser/Link.php
@@ -4,6 +4,11 @@ declare(strict_types=1);
 
 namespace Doctrine\RST\Parser;
 
+/**
+ * An explicit link *target* (internal or external).
+ *
+ * https://docutils.sourceforge.io/docs/ref/rst/restructuredtext.html#hyperlink-targets
+ */
 final class Link
 {
     public const TYPE_LINK   = 'link';

--- a/lib/References/Resolver.php
+++ b/lib/References/Resolver.php
@@ -63,7 +63,7 @@ final class Resolver
         string $data,
         array $attributes = []
     ): ?ResolvedReference {
-        $entry = $environment->getMetas()->findLinkMetaEntry($data);
+        $entry = $environment->getMetas()->findLinkTargetMetaEntry($data);
 
         if ($entry !== null) {
             return $this->createResolvedReference($entry->getFile(), $environment, $entry, $attributes, $data);

--- a/lib/Renderers/SpanNodeRenderer.php
+++ b/lib/Renderers/SpanNodeRenderer.php
@@ -162,7 +162,7 @@ abstract class SpanNodeRenderer implements NodeRenderer, SpanRenderer
         $link = $spanToken->get('link');
 
         if ($url === '') {
-            $url = $this->environment->getLink($link);
+            $url = $this->environment->getLinkTarget($link);
 
             if ($url === '') {
                 $metaEntry = $this->environment->getMetaEntry();

--- a/lib/Span/SpanProcessor.php
+++ b/lib/Span/SpanProcessor.php
@@ -193,7 +193,7 @@ final class SpanProcessor
                 $link = $m[1];
                 $url  = $m[2];
 
-                $this->environment->setLink($link, $url);
+                $this->environment->setLinkTarget($link, $url);
             }
 
             // extract the url if the link was in this format: `<https://www.google.com>`_
@@ -201,7 +201,7 @@ final class SpanProcessor
                 $link = $m[1];
                 $url  = $m[1];
 
-                $this->environment->setLink($link, $url);
+                $this->environment->setLinkTarget($link, $url);
             }
 
             $id = $this->generateId();

--- a/tests/MetasTest.php
+++ b/tests/MetasTest.php
@@ -45,9 +45,9 @@ class MetasTest extends TestCase
             $entry2,
         ]);
 
-        self::assertSame($entry1, $metas->findLinkMetaEntry('link1'));
-        self::assertSame($entry1, $metas->findLinkMetaEntry('link2'));
-        self::assertSame($entry2, $metas->findLinkMetaEntry('link3'));
-        self::assertSame($entry2, $metas->findLinkMetaEntry('link4'));
+        self::assertSame($entry1, $metas->findLinkTargetMetaEntry('link1'));
+        self::assertSame($entry1, $metas->findLinkTargetMetaEntry('link2'));
+        self::assertSame($entry2, $metas->findLinkTargetMetaEntry('link3'));
+        self::assertSame($entry2, $metas->findLinkTargetMetaEntry('link4'));
     }
 }

--- a/tests/Parser/LineDataParserTest.php
+++ b/tests/Parser/LineDataParserTest.php
@@ -32,7 +32,7 @@ class LineDataParserTest extends TestCase
         $this->eventManager->expects(self::exactly($expected instanceof Link ? 1 : 0))
             ->method('dispatchEvent');
 
-        self::assertEquals($expected, $this->lineDataParser->parseLink($line));
+        self::assertEquals($expected, $this->lineDataParser->parseLinkTarget($line));
     }
 
     /**

--- a/tests/References/ResolverTest.php
+++ b/tests/References/ResolverTest.php
@@ -78,7 +78,7 @@ class ResolverTest extends TestCase
             ->willReturn(null);
 
         $this->metas->expects(self::once())
-            ->method('findLinkMetaEntry')
+            ->method('findLinkTargetMetaEntry')
             ->willReturn($this->metaEntry);
 
         $this->environment->expects(self::once())
@@ -98,7 +98,7 @@ class ResolverTest extends TestCase
             ->willReturn(null);
 
         $this->metas->expects(self::once())
-            ->method('findLinkMetaEntry')
+            ->method('findLinkTargetMetaEntry')
             ->willReturn(null);
 
         self::assertNull($this->resolver->resolve($this->environment, 'invalid-reference'));
@@ -115,7 +115,7 @@ class ResolverTest extends TestCase
             ->willReturn(null);
 
         $this->metas->expects(self::once())
-            ->method('findLinkMetaEntry')
+            ->method('findLinkTargetMetaEntry')
             ->willReturn(null);
 
         self::assertNull($this->resolver->resolve($this->environment, 'invalid-reference'));


### PR DESCRIPTION
This is something that took me a while to understand when working on #175. For me, "links" indicate the actual thing linking to something, not the thing that is linked to. The reStructured Text spec calls these "hyperlink targets", let's use that in this library as well.

TODO:
* [x] Update UPGRADE nodes
* [x] ~Do we want to implement a BC layer?~