### PR TITLE
Allow Symfony 6

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -12,6 +12,6 @@ env:
 jobs:
   phpunit:
     name: "PHPUnit"
-    uses: "doctrine/.github/.github/workflows/continuous-integration.yml@1.1.0"
+    uses: "doctrine/.github/.github/workflows/continuous-integration.yml@1.4.1"
     with:
       php-versions: '["7.2", "7.3", "7.4", "8.0"]'

--- a/composer.json
+++ b/composer.json
@@ -19,10 +19,10 @@
     "require": {
         "php": "^7.2 || ^8.0",
         "doctrine/event-manager": "^1.0",
-        "symfony/filesystem": "^4.1 || ^5.0",
-        "symfony/finder": "^4.1 || ^5.0",
+        "symfony/filesystem": "^4.1 || ^5.0 || ^6.0",
+        "symfony/finder": "^4.1 || ^5.0 || ^6.0",
         "symfony/polyfill-mbstring": "^1.0",
-        "symfony/string": "^5.3",
+        "symfony/string": "^5.3 || ^6.0",
         "symfony/translation-contracts": "^1.1 || ^2.0",
         "twig/twig": "^2.9 || ^3.3"
     },
@@ -34,8 +34,8 @@
         "phpstan/phpstan-phpunit": "^0.12",
         "phpstan/phpstan-strict-rules": "^0.12",
         "phpunit/phpunit": "^7.5 || ^8.0 || ^9.0",
-        "symfony/css-selector": "4.4 || ^5.2",
-        "symfony/dom-crawler": "4.4 || ^5.2"
+        "symfony/css-selector": "4.4 || ^5.2 || ^6.0",
+        "symfony/dom-crawler": "4.4 || ^5.2 || ^6.0"
     },
     "autoload": {
         "psr-4": {
@@ -48,6 +48,9 @@
         }
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {
+            "dealerdirect/phpcodesniffer-composer-installer": true
+        }
     }
 }


### PR DESCRIPTION
@greg0ire I think I need your help with 2 things here :)

* If I understand the GitHub workflow config correctly, we're now testing only Symfony 4 and Symfony 6. Is that OK for you, or do we need to also test Symfony 5? (if yes, please guide me through he process :smile: )
* I've targetted 0.6.x - the dev minor release. Does Doctrine consider adding support for newer dependency versions a bugfix (similar to Symfony)? I.e. should I target 0.5.x instead?