### PR TITLE
Specify `htmlspecialchars()` flags

### DIFF
--- a/lib/HTML/Renderers/SpanNodeRenderer.php
+++ b/lib/HTML/Renderers/SpanNodeRenderer.php
@@ -13,6 +13,8 @@ use Doctrine\RST\Templates\TemplateRenderer;
 use function htmlspecialchars;
 use function trim;
 
+use const ENT_COMPAT;
+
 final class SpanNodeRenderer extends BaseSpanNodeRenderer
 {
     /** @var TemplateRenderer */
@@ -69,7 +71,7 @@ final class SpanNodeRenderer extends BaseSpanNodeRenderer
 
     public function escape(string $span): string
     {
-        return htmlspecialchars($span);
+        return htmlspecialchars($span, ENT_COMPAT);
     }
 
     /**


### PR DESCRIPTION
The test suite is broken on PHP 8.1 because the default value changed from `ENT_COMPAT` to `ENT_QUOTES | ENT_SUBSTITUTE | ENT_HTML401`

See https://www.php.net/manual/en/function.htmlspecialchars.php