### PR TITLE
Run unit tests on push

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -2,6 +2,15 @@
 name: "Continuous Integration"
 
 on:
+  push:
+    branches:
+      - "*.x"
+    paths:
+      - ".github/workflows/continuous-integration.yml"
+      - "composer.*"
+      - "lib/**"
+      - "phpunit.xml.dist"
+      - "tests/**"
   pull_request:
     branches:
       - "*.x"


### PR DESCRIPTION
I noticed that Codecov reported wrong coverage changes (for instance in #205). I believe that it might be because it compares to the wrong commit, because there is no coverage information for merge commits.