### PR TITLE
[Feature] Introduce event to intercept reference resolving

### DIFF
--- a/docs/en/events.rst
+++ b/docs/en/events.rst
@@ -73,7 +73,7 @@ The events you can listen for are as follows:
 - ``PreNodeRenderEvent::PRE_NODE_RENDER`` - Dispatches a method named ``preNodeRender()`` before a node is rendered.
 - ``PostNodeRenderEvent::POST_NODE_RENDER`` - Dispatches a method named ``postNodeRender()`` after a node is rendered.
 - ``MissingReferenceResolverEvent::PRE_REFERENCED_RESOVED`` - Dispatches a method named
-  ``resolveMissingReference()`` if a reference cannot be resolved by the build-in methods. This event can
+  ``resolveMissingReference()`` if a reference cannot be resolved by the built-in methods. This event can
   be used to override the ``ResolvedReference`` returned by ``Resolver->resolve`` and thereby implement
   other means of references, like for example intersphinx links. The event can be listened to
   in implementing projects or extending packages. See

--- a/docs/en/events.rst
+++ b/docs/en/events.rst
@@ -72,7 +72,10 @@ The events you can listen for are as follows:
 - ``PostParseDocumentEvent::POST_PARSE_DOCUMENT`` - Dispatches a method named ``postParseDocument()`` after a node is parsed.
 - ``PreNodeRenderEvent::PRE_NODE_RENDER`` - Dispatches a method named ``preNodeRender()`` before a node is rendered.
 - ``PostNodeRenderEvent::POST_NODE_RENDER`` - Dispatches a method named ``postNodeRender()`` after a node is rendered.
-- ``PreReferenceResolvedEvent::PRE_REFERENCED_RESOVED`` - Dispatches a method named
-  ``preReferenceResolved()`` before a reference is resolved. If the ``$resolvedReference``
-  of the event is set to any non null value, resolving of references is stopped
-  and the ``$resolvedReference`` of the event is used instead.
+- ``MissingReferenceResolverEvent::PRE_REFERENCED_RESOVED`` - Dispatches a method named
+  ``resolveMissingReference()`` if a reference cannot be resolved by the build-in methods. This event can
+  be used to override the ``ResolvedReference`` returned by ``Resolver->resolve`` and thereby implement
+  other means of references, like for example intersphinx links. The event can be listened to
+  in implementing projects or extending packages. See
+  `Package Intersphinx, provided by the TYPO3 Documentation Team <https://github.com/TYPO3-Documentation/intersphinx>`__
+  for an example implementation.

--- a/docs/en/events.rst
+++ b/docs/en/events.rst
@@ -72,3 +72,7 @@ The events you can listen for are as follows:
 - ``PostParseDocumentEvent::POST_PARSE_DOCUMENT`` - Dispatches a method named ``postParseDocument()`` after a node is parsed.
 - ``PreNodeRenderEvent::PRE_NODE_RENDER`` - Dispatches a method named ``preNodeRender()`` before a node is rendered.
 - ``PostNodeRenderEvent::POST_NODE_RENDER`` - Dispatches a method named ``postNodeRender()`` after a node is rendered.
+- `PreReferenceResolvedEvent::PRE_REFERENCED_RESOVED` - Dispatches a method named
+  ``preReferenceResolved()`` before a reference is resolved. If the ``$resolvedReference``
+  of the event is set to any non null value, resolving of references is stopped
+  and the ``$resolvedReference`` of the event is used instead.

--- a/docs/en/events.rst
+++ b/docs/en/events.rst
@@ -72,7 +72,7 @@ The events you can listen for are as follows:
 - ``PostParseDocumentEvent::POST_PARSE_DOCUMENT`` - Dispatches a method named ``postParseDocument()`` after a node is parsed.
 - ``PreNodeRenderEvent::PRE_NODE_RENDER`` - Dispatches a method named ``preNodeRender()`` before a node is rendered.
 - ``PostNodeRenderEvent::POST_NODE_RENDER`` - Dispatches a method named ``postNodeRender()`` after a node is rendered.
-- `PreReferenceResolvedEvent::PRE_REFERENCED_RESOVED` - Dispatches a method named
+- ``PreReferenceResolvedEvent::PRE_REFERENCED_RESOVED`` - Dispatches a method named
   ``preReferenceResolved()`` before a reference is resolved. If the ``$resolvedReference``
   of the event is set to any non null value, resolving of references is stopped
   and the ``$resolvedReference`` of the event is used instead.

--- a/lib/Event/MissingReferenceResolverEvent.php
+++ b/lib/Event/MissingReferenceResolverEvent.php
@@ -8,9 +8,9 @@ use Doctrine\Common\EventArgs;
 use Doctrine\RST\Environment;
 use Doctrine\RST\References\ResolvedReference;
 
-final class PreReferenceResolvedEvent extends EventArgs
+final class MissingReferenceResolverEvent extends EventArgs
 {
-    public const PRE_REFERENCED_RESOVED = 'preReferenceResolved';
+    public const MISSING_REFERENCE_RESOLVER = 'resolveMissingReference';
 
     /** @var Environment */
     private $environment;

--- a/lib/Event/PreReferenceResolvedEvent.php
+++ b/lib/Event/PreReferenceResolvedEvent.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\RST\Event;
+
+use Doctrine\Common\EventArgs;
+use Doctrine\RST\Environment;
+use Doctrine\RST\References\ResolvedReference;
+
+final class PreReferenceResolvedEvent extends EventArgs
+{
+    public const PRE_REFERENCED_RESOVED = 'preReferenceResolved';
+
+    /** @var Environment */
+    private $environment;
+
+    /** @var string */
+    private $data;
+
+    /** @var string[] */
+    private $attributes;
+
+    /** @var ?ResolvedReference */
+    private $resolvedReference = null;
+
+    /** @param string[] $attributes */
+    public function __construct(
+        Environment $environment,
+        string $data,
+        array $attributes
+    ) {
+        $this->environment = $environment;
+        $this->data        = $data;
+        $this->attributes  = $attributes;
+    }
+
+    public function getEnvironment(): Environment
+    {
+        return $this->environment;
+    }
+
+    public function getData(): string
+    {
+        return $this->data;
+    }
+
+    /** @return string[] */
+    public function getAttributes(): array
+    {
+        return $this->attributes;
+    }
+
+    public function getResolvedReference(): ?ResolvedReference
+    {
+        return $this->resolvedReference;
+    }
+
+    public function setResolvedReference(?ResolvedReference $resolvedReference): void
+    {
+        $this->resolvedReference = $resolvedReference;
+    }
+}

--- a/lib/References/Resolver.php
+++ b/lib/References/Resolver.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\RST\References;
 
 use Doctrine\RST\Environment;
-use Doctrine\RST\Event\PreReferenceResolvedEvent;
+use Doctrine\RST\Event\MissingReferenceResolverEvent;
 use Doctrine\RST\Meta\MetaEntry;
 
 final class Resolver
@@ -18,17 +18,6 @@ final class Resolver
     ): ?ResolvedReference {
         $eventManager = $environment->getConfiguration()->getEventManager();
 
-        $preReferenceResolvedEvent = new PreReferenceResolvedEvent($environment, $data, $attributes);
-
-        $eventManager->dispatchEvent(
-            PreReferenceResolvedEvent::PRE_REFERENCED_RESOVED,
-            $preReferenceResolvedEvent
-        );
-
-        if ($preReferenceResolvedEvent->getResolvedReference() !== null) {
-            return $preReferenceResolvedEvent->getResolvedReference();
-        }
-
         $resolvedFileReference = $this->resolveFileReference($environment, $data, $attributes);
 
         if ($resolvedFileReference !== null) {
@@ -39,6 +28,17 @@ final class Resolver
 
         if ($resolvedAnchorReference !== null) {
             return $resolvedAnchorReference;
+        }
+
+        $missingReferenceResolverEvent = new MissingReferenceResolverEvent($environment, $data, $attributes);
+
+        $eventManager->dispatchEvent(
+            MissingReferenceResolverEvent::MISSING_REFERENCE_RESOLVER,
+            $missingReferenceResolverEvent
+        );
+
+        if ($missingReferenceResolverEvent->getResolvedReference() !== null) {
+            return $missingReferenceResolverEvent->getResolvedReference();
         }
 
         return null;

--- a/lib/References/Resolver.php
+++ b/lib/References/Resolver.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\RST\References;
 
 use Doctrine\RST\Environment;
+use Doctrine\RST\Event\PreReferenceResolvedEvent;
 use Doctrine\RST\Meta\MetaEntry;
 
 final class Resolver
@@ -15,6 +16,19 @@ final class Resolver
         string $data,
         array $attributes = []
     ): ?ResolvedReference {
+        $eventManager = $environment->getConfiguration()->getEventManager();
+
+        $preReferenceResolvedEvent = new PreReferenceResolvedEvent($environment, $data, $attributes);
+
+        $eventManager->dispatchEvent(
+            PreReferenceResolvedEvent::PRE_REFERENCED_RESOVED,
+            $preReferenceResolvedEvent
+        );
+
+        if ($preReferenceResolvedEvent->getResolvedReference() !== null) {
+            return $preReferenceResolvedEvent->getResolvedReference();
+        }
+
         $resolvedFileReference = $this->resolveFileReference($environment, $data, $attributes);
 
         if ($resolvedFileReference !== null) {

--- a/tests/References/Listener/SimpleMissingReferenceResolverListener.php
+++ b/tests/References/Listener/SimpleMissingReferenceResolverListener.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\RST\References\Listener;
+
+use Doctrine\RST\Event\MissingReferenceResolverEvent;
+use Doctrine\RST\References\ResolvedReference;
+
+class SimpleMissingReferenceResolverListener
+{
+    public function resolveMissingReference(MissingReferenceResolverEvent $event): void
+    {
+        $file              = null;
+        $title             = 'example';
+        $url               = 'https://example.com/';
+        $resolvedReference = new ResolvedReference($file, $title, $url);
+        $event->setResolvedReference($resolvedReference);
+    }
+}

--- a/tests/References/ResolverTest.php
+++ b/tests/References/ResolverTest.php
@@ -4,11 +4,15 @@ declare(strict_types=1);
 
 namespace Doctrine\Tests\RST\References;
 
+use Doctrine\Common\EventManager;
+use Doctrine\RST\Configuration;
 use Doctrine\RST\Environment;
+use Doctrine\RST\Event\MissingReferenceResolverEvent;
 use Doctrine\RST\Meta\MetaEntry;
 use Doctrine\RST\Meta\Metas;
 use Doctrine\RST\References\ResolvedReference;
 use Doctrine\RST\References\Resolver;
+use Doctrine\Tests\RST\References\Listener\SimpleMissingReferenceResolverListener;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
@@ -22,6 +26,9 @@ class ResolverTest extends TestCase
 
     /** @var MetaEntry|MockObject */
     private $metaEntry;
+
+    /** @var Configuration|MockObject */
+    private $configuration;
 
     /** @var Resolver */
     private $resolver;
@@ -47,6 +54,8 @@ class ResolverTest extends TestCase
         $this->metaEntry->expects(self::any())
             ->method('getTitles')
             ->willReturn([]);
+
+        $this->configuration = $this->createMock(Configuration::class);
 
         $this->resolver = new Resolver();
     }
@@ -119,5 +128,24 @@ class ResolverTest extends TestCase
             ->willReturn(null);
 
         self::assertNull($this->resolver->resolve($this->environment, 'invalid-reference'));
+    }
+
+    public function testMissingReferenceResolverEventDispatched(): void
+    {
+        $this->environment->expects(self::any())
+            ->method('getConfiguration')
+            ->willReturn($this->configuration);
+        $eventManager = new EventManager();
+        $eventManager->addEventListener(
+            [MissingReferenceResolverEvent::MISSING_REFERENCE_RESOLVER],
+            new SimpleMissingReferenceResolverListener()
+        );
+        $this->configuration->expects(self::any())
+            ->method('getEventManager')
+            ->willReturn($eventManager);
+        self::assertEquals(
+            new ResolvedReference(null, 'example', 'https://example.com/', [], []),
+            $this->resolver->resolve($this->environment, 'unknown-reference')
+        );
     }
 }

--- a/tests/References/ResolverTest.php
+++ b/tests/References/ResolverTest.php
@@ -132,7 +132,7 @@ class ResolverTest extends TestCase
 
     public function testMissingReferenceResolverEventDispatched(): void
     {
-        $this->environment->expects(self::any())
+        $this->environment
             ->method('getConfiguration')
             ->willReturn($this->configuration);
         $eventManager = new EventManager();
@@ -140,7 +140,7 @@ class ResolverTest extends TestCase
             [MissingReferenceResolverEvent::MISSING_REFERENCE_RESOLVER],
             new SimpleMissingReferenceResolverListener()
         );
-        $this->configuration->expects(self::any())
+        $this->configuration
             ->method('getEventManager')
             ->willReturn($eventManager);
         self::assertEquals(


### PR DESCRIPTION
This event makes it possible to create an event that resolves intersphinx links of the format
```
:ref:`myproject:mylink`
```

for example using the event to override the resolved reference.

references https://github.com/doctrine/rst-parser/issues/208