### PR TITLE
[Task] Drop PHP support below 7.4

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -29,4 +29,4 @@ jobs:
     name: "PHPUnit"
     uses: "doctrine/.github/.github/workflows/continuous-integration.yml@2.1.0"
     with:
-      php-versions: '["7.2", "7.3", "7.4", "8.0", "8.1", "8.2"]'
+      php-versions: '["7.4", "8.0", "8.1", "8.2"]'

--- a/composer.json
+++ b/composer.json
@@ -24,14 +24,14 @@
     ],
     "homepage": "https://github.com/doctrine/rst-parser",
     "require": {
-        "php": "^7.2 || ^8.0",
+        "php": "^7.4 || ^8.0",
         "doctrine/event-manager": "^1.0",
         "symfony/filesystem": "^4.1 || ^5.0 || ^6.0",
         "symfony/finder": "^4.1 || ^5.0 || ^6.0",
         "symfony/polyfill-mbstring": "^1.0",
         "symfony/string": "^5.3 || ^6.0",
         "symfony/translation-contracts": "^1.1 || ^2.0",
-        "twig/twig": "^2.9 || ^3.3"
+        "twig/twig": "^2.15.3 || ^3.4.3"
     },
     "require-dev": {
         "doctrine/coding-standard": "^10.0",
@@ -40,7 +40,7 @@
         "phpstan/phpstan-deprecation-rules": "^1.0",
         "phpstan/phpstan-phpunit": "^1.2",
         "phpstan/phpstan-strict-rules": "^1.4",
-        "phpunit/phpunit": "^7.5 || ^8.0 || ^9.0",
+        "phpunit/phpunit": "^9.5",
         "symfony/css-selector": "4.4 || ^5.2 || ^6.0",
         "symfony/dom-crawler": "4.4 || ^5.2 || ^6.0"
     },


### PR DESCRIPTION
This way we can use property types etc in the future

Due to this bug: https://github.com/twigphp/Twig/issues/3151 we have to use more recent versions of twig. The rest of the errors required a more recent version of phpunit

resolves https://github.com/doctrine/rst-parser/issues/210