### PR TITLE
[BUGFIX] Ignore case in directive names

### DIFF
--- a/lib/Parser/Directive.php
+++ b/lib/Parser/Directive.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Doctrine\RST\Parser;
 
+use function strtolower;
+
 final class Directive
 {
     /** @var string */
@@ -22,9 +24,10 @@ final class Directive
     public function __construct(string $variable, string $name, string $data, array $options = [])
     {
         $this->variable = $variable;
-        $this->name     = $name;
-        $this->data     = $data;
-        $this->options  = $options;
+        // Directive names are case-insensitive
+        $this->name    = strtolower($name);
+        $this->data    = $data;
+        $this->options = $options;
     }
 
     public function getVariable(): string

--- a/tests/Functional/tests/render/directive-ignore-case/directive-ignore-case.html
+++ b/tests/Functional/tests/render/directive-ignore-case/directive-ignore-case.html
@@ -1,0 +1,20 @@
+<div class="alert tip-admonition bg-success text-light border ">
+    <table width="100%">
+        <tr>
+            <td width="10" class="align-top" title="Tip"><i class="fas fa-question-circle mr-2"></i></td>
+            <td>
+                <p>This is a Tip</p>
+            </td>
+        </tr>
+    </table>
+</div>
+<div class="alert tip-admonition bg-success text-light border ">
+    <table width="100%">
+        <tr>
+            <td width="10" class="align-top" title="Tip"><i class="fas fa-question-circle mr-2"></i></td>
+            <td>
+                <p>This is a TIP</p>
+            </td>
+        </tr>
+    </table>
+</div>

--- a/tests/Functional/tests/render/directive-ignore-case/directive-ignore-case.rst
+++ b/tests/Functional/tests/render/directive-ignore-case/directive-ignore-case.rst
@@ -1,0 +1,5 @@
+.. Tip::
+    This is a Tip
+
+.. TIP::
+    This is a TIP


### PR DESCRIPTION
This might be a breaking change for some projects that relied on directives beeing case-sensitive. However Sphinx is not case sensitive so I would suggest to switch this.

references https://github.com/doctrine/rst-parser/issues/187