### PR TITLE
Allow block of comments

### DIFF
--- a/lib/Parser/DocumentParser.php
+++ b/lib/Parser/DocumentParser.php
@@ -274,6 +274,13 @@ final class DocumentParser
                         return false;
                     }
 
+                    if ($this->lineChecker->isComment($line)) {
+                        $this->flush();
+                        $this->setState(State::COMMENT);
+
+                        return false;
+                    }
+
                     if ($this->parseLink($line)) {
                         return true;
                     }
@@ -426,8 +433,6 @@ final class DocumentParser
                 break;
 
             case State::COMMENT:
-                $isComment = false;
-
                 if (! $this->lineChecker->isComment($line) && (trim($line) === '' || $line[0] !== ' ')) {
                     $this->setState(State::BEGIN);
 

--- a/lib/Parser/LineChecker.php
+++ b/lib/Parser/LineChecker.php
@@ -109,12 +109,12 @@ class LineChecker
      */
     public function isBlockLine(string $line, int $minIndent = 1): bool
     {
-        return trim($line) === '' || $this->isIndented($line, $minIndent);
+        return (trim($line) === '' || $this->isIndented($line, $minIndent)) && ! $this->isComment($line);
     }
 
     public function isComment(string $line): bool
     {
-        return preg_match('/^\.\. (.*)$/mUsi', $line) > 0;
+        return preg_match('/^\.\.(?: [^_]((?:(?!::).)*))?$/mUsi', $line) > 0;
     }
 
     public function isDirective(string $line): bool

--- a/tests/Functional/tests/render/comment-empty/comment-empty.html
+++ b/tests/Functional/tests/render/comment-empty/comment-empty.html
@@ -1,0 +1,4 @@
+<p>this is not a comment</p>
+<blockquote>
+    <p>this is a blockquote</p>
+</blockquote>

--- a/tests/Functional/tests/render/comment-empty/comment-empty.rst
+++ b/tests/Functional/tests/render/comment-empty/comment-empty.rst
@@ -1,0 +1,6 @@
+..
+this is not a comment
+
+..
+
+  this is a blockquote

--- a/tests/Functional/tests/render/comments-block-with-header/comments-block-with-header.html
+++ b/tests/Functional/tests/render/comments-block-with-header/comments-block-with-header.html
@@ -1,0 +1,1 @@
+<p>this is not a comment</p>

--- a/tests/Functional/tests/render/comments-block-with-header/comments-block-with-header.rst
+++ b/tests/Functional/tests/render/comments-block-with-header/comments-block-with-header.rst
@@ -1,0 +1,3 @@
+.. header comment
+   this is a comment
+this is not a comment

--- a/tests/Functional/tests/render/comments-block/comments-block.html
+++ b/tests/Functional/tests/render/comments-block/comments-block.html
@@ -1,0 +1,1 @@
+<p>this is not a comment</p>

--- a/tests/Functional/tests/render/comments-block/comments-block.rst
+++ b/tests/Functional/tests/render/comments-block/comments-block.rst
@@ -1,0 +1,3 @@
+..
+  this is a comment
+this is not a comment

--- a/tests/Parser/LineCheckerTest.php
+++ b/tests/Parser/LineCheckerTest.php
@@ -56,7 +56,15 @@ class LineCheckerTest extends TestCase
     public function testIsComment(): void
     {
         self::assertTrue($this->lineChecker->isComment('.. Test'));
+        self::assertTrue($this->lineChecker->isComment('..'));
+        self::assertTrue($this->lineChecker->isComment('.. with _ underscore'));
+        self::assertTrue($this->lineChecker->isComment('.. with : colon'));
+        self::assertTrue($this->lineChecker->isComment('.. can finish with colon:'));
+
         self::assertFalse($this->lineChecker->isComment('Test'));
+        self::assertFalse($this->lineChecker->isComment('.. _should not start with underscore'));
+        self::assertFalse($this->lineChecker->isComment('.. should not finish with double colon::'));
+        self::assertFalse($this->lineChecker->isComment('.. should contain::double colon'));
     }
 
     public function testIsDirective(): void


### PR DESCRIPTION
Hello,

this PR refers to this problem in symfony's docs
https://github.com/symfony/symfony-docs/pull/17627

the parser currently does not understand "comments blocks"
```rst
..
  this is a comment
```
or "comments block with header"
```rst
.. header comment
   this is a comment

not a comment anymore
```

see RST docs: https://docutils.sourceforge.io/docs/ref/rst/restructuredtext.html#comments