### PR TITLE
[TASK] Compare lines in HTML functional tests trimmed

### DIFF
--- a/tests/Functional/FunctionalTest.php
+++ b/tests/Functional/FunctionalTest.php
@@ -24,7 +24,6 @@ use function file_get_contents;
 use function implode;
 use function in_array;
 use function is_string;
-use function rtrim;
 use function setlocale;
 use function sprintf;
 use function str_replace;
@@ -235,7 +234,7 @@ class FunctionalTest extends TestCase
         $lines = explode("\n", $string);
 
         $lines = array_map(static function (string $line): string {
-            return rtrim($line);
+            return trim($line);
         }, $lines);
 
         return trim(implode("\n", $lines));

--- a/tests/Functional/tests/build/toctree/index.html
+++ b/tests/Functional/tests/build/toctree/index.html
@@ -3,14 +3,14 @@
     <head>
         <meta charset="utf-8" />
 
-            
+
     </head>
 
     <body>
-            <div class="section" id="index">
-<h1>index</h1>
-<div class="toc"><ul><li id="page1-html" class="toc-item"><a href="page1.html">Page 1</a><ul><li id="page1-html-chapter-1" class="toc-item"><a href="page1.html#chapter-1">Chapter 1</a></li><li id="page1-html-chapter-2" class="toc-item"><a href="page1.html#chapter-2">Chapter 2</a></li></ul></li><li id="page2-html" class="toc-item"><a href="page2.html">Page 2</a></li></ul></div>
-</div>
+        <div class="section" id="index">
+            <h1>index</h1>
+            <div class="toc"><ul><li id="page1-html" class="toc-item"><a href="page1.html">Page 1</a><ul><li id="page1-html-chapter-1" class="toc-item"><a href="page1.html#chapter-1">Chapter 1</a></li><li id="page1-html-chapter-2" class="toc-item"><a href="page1.html#chapter-2">Chapter 2</a></li></ul></li><li id="page2-html" class="toc-item"><a href="page2.html">Page 2</a></li></ul></div>
+        </div>
 
     </body>
 </html>

--- a/tests/Functional/tests/render/tip-multiline/tip-multiline.html
+++ b/tests/Functional/tests/render/tip-multiline/tip-multiline.html
@@ -4,8 +4,8 @@
             <td width="10" class="align-top" title="Tip"><i class="fas fa-question-circle mr-2"></i></td>
             <td>
                 <p>Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy
-eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam
-voluptua. At vero eos et accusam et justo duo dolores et ea rebum.</p>
+                eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam
+                voluptua. At vero eos et accusam et justo duo dolores et ea rebum.</p>
             </td>
         </tr>
     </table>


### PR DESCRIPTION
Adjusting the whitespace in HTML files to what our renderer outputs is tiresome.

And nice formating of the html is really not in the scope of this project.  Multiple whitespaces are ignored in HTML anyway. So I would suggest to trim the lines before comparing instead of rtrimming them.

Adjusted 2 Tests to demonstrate this is wokring.

A follow up which compares the HTML structure in a more logical way would be nice but having this already makes testing much easier without giving up acuracy