### PR TITLE
[BUGFIX] Fix Unkown Textrole to throw no error

### DIFF
--- a/lib/Environment.php
+++ b/lib/Environment.php
@@ -87,10 +87,10 @@ class Environment
     /** @var InvalidLink[] */
     private $invalidLinks = [];
 
-    public function __construct(Configuration $configuration)
+    public function __construct(Configuration $configuration, ?ErrorManager $errorManager = null)
     {
         $this->configuration = $configuration;
-        $this->errorManager  = new ErrorManager($this->configuration);
+        $this->errorManager  = $errorManager ?? new ErrorManager($this->configuration);
         $this->urlGenerator  = new UrlGenerator(
             $this->configuration
         );

--- a/lib/Renderers/SpanNodeRenderer.php
+++ b/lib/Renderers/SpanNodeRenderer.php
@@ -149,6 +149,10 @@ abstract class SpanNodeRenderer implements NodeRenderer, SpanRenderer
 
         $textRole = $this->environment->getTextRole($spanToken->get('section'));
 
+        if ($textRole === null) {
+            return $spanToken->get('url');
+        }
+
         return $textRole->process($spanToken->get('url'));
     }
 

--- a/tests/TextRoles/EnvironmentTest.php
+++ b/tests/TextRoles/EnvironmentTest.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\RST\TextRoles;
+
+use Doctrine\RST\Configuration;
+use Doctrine\RST\Environment;
+use Doctrine\RST\ErrorManager;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class EnvironmentTest extends TestCase
+{
+    private Environment $environment;
+    /** @var ErrorManager|MockObject */
+    private $errorManager;
+
+    protected function setUp(): void
+    {
+        $configuration      = new Configuration();
+        $this->errorManager = $this->createMock(ErrorManager::class);
+        $this->environment  = new Environment($configuration, $this->errorManager);
+    }
+
+    public function testRegisterTextRole(): void
+    {
+        $role = new ExampleRole();
+        $this->errorManager->expects(self::never())->method('warning');
+        $this->errorManager->expects(self::never())->method('error');
+        $this->environment->registerTextRole($role);
+        self:self::assertEquals($role, $this->environment->getTextRole('example'));
+    }
+
+    public function testUnkownTextRole(): void
+    {
+        $this->errorManager->expects(self::atLeastOnce())->method('error');
+        self:self::assertNull($this->environment->getTextRole('unkown'));
+    }
+}

--- a/tests/TextRoles/ExampleRole.php
+++ b/tests/TextRoles/ExampleRole.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\RST\TextRoles;
+
+use Doctrine\RST\TextRoles\TextRole;
+
+class ExampleRole extends TextRole
+{
+    public function getName(): string
+    {
+        return 'example';
+    }
+
+    public function process(string $text): string
+    {
+        return '<samp>' . $text . '</samp>';
+    }
+}

--- a/tests/TextRoles/SpanNodeRendererTest.php
+++ b/tests/TextRoles/SpanNodeRendererTest.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\RST\TextRoles;
+
+use Doctrine\RST\Environment;
+use Doctrine\RST\HTML\Renderers\SpanNodeRenderer;
+use Doctrine\RST\Nodes\SpanNode;
+use Doctrine\RST\Span\SpanToken;
+use Doctrine\RST\Templates\TemplateRenderer;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class SpanNodeRendererTest extends TestCase
+{
+    /** @var Environment|MockObject */
+    private $environment;
+    /** @var SpanNode|MockObject */
+    private $spanNode;
+    /** @var TemplateRenderer|MockObject */
+    private $templateRenderer;
+
+    private SpanNodeRenderer $spanNodeRenderer;
+
+    protected function setUp(): void
+    {
+        $this->environment      = $this->createMock(Environment::class);
+        $this->spanNode         = $this->createMock(SpanNode::class);
+        $this->templateRenderer = $this->createMock(TemplateRenderer::class);
+        $this->spanNodeRenderer = new SpanNodeRenderer($this->environment, $this->spanNode, $this->templateRenderer);
+    }
+
+    public function testExampleRoleWrapsContent(): void
+    {
+        $expected = '<samp>Example</samp>';
+        $this->spanNode->method('getTokens')->willReturn([new SpanToken(SpanToken::TYPE_TEXT_ROLE, 'id', ['url' => 'Example'])]);
+        $this->environment->method('getTextRole')->willReturn(new ExampleRole());
+        self::assertEquals($expected, $this->spanNodeRenderer->render());
+    }
+
+    public function testUnkownRole(): void
+    {
+        $expected = 'Example';
+        $this->spanNode->method('getTokens')->willReturn([new SpanToken(SpanToken::TYPE_TEXT_ROLE, 'id', ['url' => 'Example'])]);
+        $this->environment->method('getTextRole')->willReturn(null);
+        self::assertEquals($expected, $this->spanNodeRenderer->render());
+    }
+}


### PR DESCRIPTION
This was throwing a NullPointer Exception until now

Add some tests, make error manager configurable for Enviroment so that it can be mocked (or custom error handling installed)