### PR TITLE
[FEATURE] Register link anchors globally in Metas

### DIFF
--- a/lib/Builder.php
+++ b/lib/Builder.php
@@ -55,17 +55,17 @@ final class Builder
     /** @var string */
     private $indexName = 'index';
 
-    public function __construct(?Kernel $kernel = null)
+    public function __construct(?Kernel $kernel = null, ?ErrorManager $errorManager = null)
     {
         $this->kernel = $kernel ?? new Kernel();
 
         $this->configuration = $this->kernel->getConfiguration();
 
-        $this->errorManager = new ErrorManager($this->configuration);
+        $this->errorManager = $errorManager ?? new ErrorManager($this->configuration);
 
         $this->filesystem = new Filesystem();
 
-        $this->metas = new Metas();
+        $this->metas = new Metas($this->errorManager);
 
         $this->cachedMetasLoader = new CachedMetasLoader();
 

--- a/lib/Meta/CachedMetasLoader.php
+++ b/lib/Meta/CachedMetasLoader.php
@@ -9,9 +9,7 @@ use LogicException;
 use function file_exists;
 use function file_get_contents;
 use function file_put_contents;
-use function serialize;
 use function sprintf;
-use function unserialize;
 
 final class CachedMetasLoader
 {
@@ -28,12 +26,12 @@ final class CachedMetasLoader
             throw new LogicException(sprintf('Could not load file "%s"', $contents));
         }
 
-        $metas->setMetaEntries(unserialize($contents));
+        $metas->unserialize($contents);
     }
 
     public function cacheMetaEntries(string $targetDirectory, Metas $metas): void
     {
-        file_put_contents($this->getMetaCachePath($targetDirectory), serialize($metas->getAll()));
+        file_put_contents($this->getMetaCachePath($targetDirectory), $metas->serialize());
     }
 
     private function getMetaCachePath(string $targetDirectory): string

--- a/lib/Meta/LinkTarget.php
+++ b/lib/Meta/LinkTarget.php
@@ -13,6 +13,7 @@ class LinkTarget
     private string $url;
     private ?string $title;
     private bool $anonymous = false;
+    private bool $duplicate = false;
 
     public function __construct(
         string $name,
@@ -28,6 +29,21 @@ class LinkTarget
     public function getName(): string
     {
         return $this->name;
+    }
+
+    public function setName(string $name): void
+    {
+        $this->name = $name;
+    }
+
+    public function isDuplicate(): bool
+    {
+        return $this->duplicate;
+    }
+
+    public function setDuplicate(bool $duplicate): void
+    {
+        $this->duplicate = $duplicate;
     }
 
     public function getUrl(): string

--- a/lib/Meta/Metas.php
+++ b/lib/Meta/Metas.php
@@ -5,8 +5,15 @@ declare(strict_types=1);
 namespace Doctrine\RST\Meta;
 
 use Doctrine\RST\Environment;
+use Doctrine\RST\ErrorManager;
+use Doctrine\RST\UrlGenerator;
 
+use function array_key_exists;
+use function array_merge;
+use function serialize;
 use function strtolower;
+use function trim;
+use function unserialize;
 
 class Metas
 {
@@ -16,10 +23,20 @@ class Metas
     /** @var string[] */
     private $parents = [];
 
-    /** @param MetaEntry[] $entries */
-    public function __construct(array $entries = [])
+    /** @var array<string, LinkTarget> */
+    private array $linkTargets = [];
+
+    private ErrorManager $errorManager;
+
+    /**
+     * @param MetaEntry[]               $entries
+     * @param array<string, LinkTarget> $linkTargets
+     */
+    public function __construct(ErrorManager $errorManager, array $entries = [], array $linkTargets = [])
     {
-        $this->entries = $entries;
+        $this->errorManager = $errorManager;
+        $this->entries      = $entries;
+        $this->linkTargets  = $linkTargets;
     }
 
     public function findLinkTargetMetaEntry(string $linkTarget): ?MetaEntry
@@ -83,6 +100,8 @@ class Metas
         }
 
         $this->entries[$file]->setParent($this->parents[$file]);
+
+        $this->linkTargets = array_merge($this->linkTargets, $linkTargets);
     }
 
     public function get(string $url): ?MetaEntry
@@ -124,5 +143,73 @@ class Metas
         }
 
         return null;
+    }
+
+    /** @return array<string, LinkTarget> */
+    public function getLinkTargets(): array
+    {
+        return $this->linkTargets;
+    }
+
+    public function setLinkTarget(string $name, LinkTarget $linkTarget): void
+    {
+        if (array_key_exists($name, $this->linkTargets)) {
+            $this->errorManager->warning('Duplicate anchor ".. _' . $linkTarget->getName() . '" found.');
+            $i = 2;
+            while (array_key_exists($name . '-' . $i, $this->linkTargets)) {
+                $i++;
+            }
+
+            $name .= '-' . $i;
+            $linkTarget->setName($name);
+            $linkTarget->setDuplicate(true);
+        }
+
+        $this->linkTargets[$name] = $linkTarget;
+    }
+
+    public function getLinkTarget(UrlGenerator $urlGenerator, string $currentFileName, string $name, bool $relative = true): ?LinkTarget
+    {
+        $name = trim(strtolower($name));
+
+        if (isset($this->linkTargets[$name])) {
+            $link = $this->linkTargets[$name];
+
+            if ($relative) {
+                return $this->makeLinkTargetRelative($urlGenerator, $currentFileName, $link);
+            }
+
+            return $link;
+        }
+
+        return null;
+    }
+
+    public function makeLinkTargetRelative(UrlGenerator $urlGenerator, string $currentFileName, LinkTarget $linkTarget): LinkTarget
+    {
+        $url = $urlGenerator->relativeUrl($linkTarget->getUrl(), $currentFileName);
+        $linkTarget->setUrl($url);
+
+        return $linkTarget;
+    }
+
+    public function hasLinkTarget(string $name): bool
+    {
+        return array_key_exists($name, $this->linkTargets);
+    }
+
+    public function serialize(): string
+    {
+        return serialize([
+            'entries' => $this->entries,
+            'linkTargets' => $this->linkTargets,
+        ]);
+    }
+
+    public function unserialize(string $serializedData): void
+    {
+        $data              = unserialize($serializedData);
+        $this->entries     = $data['entries'] ?? [];
+        $this->linkTargets = $data['linkTargets'] ?? [];
     }
 }

--- a/lib/Parser/DocumentParser.php
+++ b/lib/Parser/DocumentParser.php
@@ -559,7 +559,7 @@ final class DocumentParser
                         $url        = Environment::slugify($link->getUrl());
                         $linkTarget = new LinkTarget($link->getName(), $url, $data);
                         $this->environment->setLinkTarget($linkTarget);
-                        $titleAnchor = Environment::slugify($url);
+                        $titleAnchor = Environment::slugify($linkTarget->getName());
                     }
 
                     $node = $this->nodeFactory->createTitleNode(

--- a/tests/Builder/BuilderTest.php
+++ b/tests/Builder/BuilderTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Doctrine\Tests\RST\Builder;
 
 use Doctrine\RST\Builder;
-use Doctrine\RST\Meta\MetaEntry;
 use Doctrine\Tests\RST\BaseBuilderTest;
 use Symfony\Component\DomCrawler\Crawler;
 
@@ -56,10 +55,15 @@ class BuilderTest extends BaseBuilderTest
         // check that metas were cached
         self::assertTrue(file_exists($this->targetFile('metas.php')));
         $cachedContents = (string) file_get_contents($this->targetFile('metas.php'));
-        /** @var MetaEntry[] $metaEntries */
-        $metaEntries = unserialize($cachedContents);
+        $metas          = unserialize($cachedContents);
+        self::assertArrayHasKey('entries', $metas);
+        $metaEntries = $metas['entries'];
         self::assertArrayHasKey('index', $metaEntries);
         self::assertSame('Summary', $metaEntries['index']->getTitle());
+        self::assertArrayHasKey('linkTargets', $metas);
+        $linkTargets = $metas['linkTargets'];
+        self::assertArrayHasKey('toc', $linkTargets);
+        self::assertSame('toc', $linkTargets['toc']->getName());
 
         // look at all the other documents this document depends
         // on, like :doc: and :ref:
@@ -363,7 +367,7 @@ class BuilderTest extends BaseBuilderTest
         );
 
         self::assertStringContainsString(
-            '<p>see <a href="magic-link.html#test">test</a></p>',
+            '<p>see <a href="http://absolute/">test</a></p>',
             $contents
         );
 

--- a/tests/BuilderDuplicateAnchors/BuilderDuplicateAnchorsTest.php
+++ b/tests/BuilderDuplicateAnchors/BuilderDuplicateAnchorsTest.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\RST\BuilderDuplicateAnchors;
+
+use Doctrine\RST\Builder;
+use Doctrine\RST\Configuration;
+use Doctrine\RST\ErrorManager;
+use Doctrine\RST\Kernel;
+use Doctrine\Tests\RST\BaseBuilderTest;
+use PHPUnit\Framework\MockObject\MockObject;
+
+class BuilderDuplicateAnchorsTest extends BaseBuilderTest
+{
+    private Configuration $configuration;
+
+    /** @var ErrorManager|MockObject */
+    private $errorManager;
+
+    protected function setUp(): void
+    {
+        $this->configuration = new Configuration();
+        $this->configuration->setUseCachedMetas(false);
+
+        $this->errorManager = $this->createMock(ErrorManager::class);
+        $this->builder      = new Builder(new Kernel($this->configuration), $this->errorManager);
+    }
+
+    public function testDuplicateReferenceSetsWarning(): void
+    {
+        $this->errorManager->expects(self::atLeastOnce())->method('warning');
+        $this->builder->build($this->sourceFile(), $this->targetFile());
+    }
+
+    public function testInvalidReferenceRenamed(): void
+    {
+        $this->configuration->setIgnoreInvalidReferences(true);
+
+        $this->builder->build($this->sourceFile(), $this->targetFile());
+
+        $contents = $this->getFileContents($this->targetFile('index.html'));
+
+        self::assertStringContainsString(' id="an-anchor-2"', $contents);
+    }
+
+    protected function getFixturesDirectory(): string
+    {
+        return 'BuilderDuplicateAnchors';
+    }
+}

--- a/tests/BuilderDuplicateAnchors/input/index.rst
+++ b/tests/BuilderDuplicateAnchors/input/index.rst
@@ -1,0 +1,16 @@
+
+.. _an_anchor:
+
+Headline one
+============
+
+Lorem ipsum
+
+
+.. _an_anchor:
+
+Headline two
+============
+
+Lorem ipsum too
+

--- a/tests/BuilderDuplicateAnchorsInTwoFiles/BuilderDuplicateAnchorsInTwoFilesTest.php
+++ b/tests/BuilderDuplicateAnchorsInTwoFiles/BuilderDuplicateAnchorsInTwoFilesTest.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\RST\BuilderDuplicateAnchorsInTwoFiles;
+
+use Doctrine\RST\Builder;
+use Doctrine\RST\Configuration;
+use Doctrine\RST\ErrorManager;
+use Doctrine\RST\Kernel;
+use Doctrine\Tests\RST\BaseBuilderTest;
+use PHPUnit\Framework\MockObject\MockObject;
+
+class BuilderDuplicateAnchorsInTwoFilesTest extends BaseBuilderTest
+{
+    private Configuration $configuration;
+
+    /** @var ErrorManager|MockObject */
+    private $errorManager;
+
+    protected function setUp(): void
+    {
+        $this->configuration = new Configuration();
+        $this->configuration->setUseCachedMetas(false);
+
+        $this->errorManager = $this->createMock(ErrorManager::class);
+        $this->builder      = new Builder(new Kernel($this->configuration), $this->errorManager);
+    }
+
+    public function testDuplicateReferenceSetsWarning(): void
+    {
+        $this->errorManager->expects(self::atLeastOnce())->method('warning');
+        $this->builder->build($this->sourceFile(), $this->targetFile());
+    }
+
+    public function testInvalidReferenceRenamed(): void
+    {
+        $this->configuration->setIgnoreInvalidReferences(true);
+
+        $this->builder->build($this->sourceFile(), $this->targetFile());
+
+        // One of the two anchors has to be renamed. It does not matter which one
+        $contents  = $this->getFileContents($this->targetFile('duplicateAnchor.html'));
+        $contents .= $this->getFileContents($this->targetFile('index.html'));
+
+        self::assertStringContainsString(' id="an-anchor-2"', $contents);
+    }
+
+    protected function getFixturesDirectory(): string
+    {
+        return 'BuilderDuplicateAnchorsInTwoFiles';
+    }
+}

--- a/tests/BuilderDuplicateAnchorsInTwoFiles/input/duplicateAnchor.rst
+++ b/tests/BuilderDuplicateAnchorsInTwoFiles/input/duplicateAnchor.rst
@@ -1,0 +1,7 @@
+
+.. _an_anchor:
+
+Headline two
+============
+
+Lorem ipsum too

--- a/tests/BuilderDuplicateAnchorsInTwoFiles/input/index.rst
+++ b/tests/BuilderDuplicateAnchorsInTwoFiles/input/index.rst
@@ -1,0 +1,11 @@
+
+.. _an_anchor:
+
+Headline one
+============
+
+Lorem ipsum
+
+.. toctree::
+
+    duplicateAnchor

--- a/tests/Meta/CachedMetasLoaderTest.php
+++ b/tests/Meta/CachedMetasLoaderTest.php
@@ -4,27 +4,53 @@ declare(strict_types=1);
 
 namespace Doctrine\Tests\RST\Meta;
 
+use Doctrine\RST\ErrorManager;
 use Doctrine\RST\Meta\CachedMetasLoader;
+use Doctrine\RST\Meta\LinkTarget;
 use Doctrine\RST\Meta\MetaEntry;
 use Doctrine\RST\Meta\Metas;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
 use function sys_get_temp_dir;
 
 class CachedMetasLoaderTest extends TestCase
 {
+    /** @var ErrorManager|MockObject */
+    private ErrorManager $errorManager;
+
+    protected function setUp(): void
+    {
+        $this->errorManager = $this->createMock(ErrorManager::class);
+    }
+
     public function testSaveAndLoadCachedMetaEntries(): void
     {
         $targetDir = sys_get_temp_dir();
         $meta1     = new MetaEntry('file1', 'url1', 'title1', [], [], [], [], 0);
         $meta2     = new MetaEntry('file2', 'url2', 'title2', [], [], [], [], 0);
 
-        $metasBefore = new Metas([$meta1, $meta2]);
-        $metasAfter  = new Metas();
+        $metasBefore = new Metas($this->errorManager, [$meta1, $meta2]);
+        $metasAfter  = new Metas($this->errorManager);
 
         $loader = new CachedMetasLoader();
         $loader->cacheMetaEntries($targetDir, $metasBefore);
         $loader->loadCachedMetaEntries($targetDir, $metasAfter);
         self::assertEquals([$meta1, $meta2], $metasAfter->getAll());
+    }
+
+    public function testSaveAndLoadCachedLinkTargets(): void
+    {
+        $targetDir  = sys_get_temp_dir();
+        $linkEntry1 = new LinkTarget('name1', 'url1', 'Some Title');
+        $linkEntry2 = new LinkTarget('name2', 'url2');
+
+        $metasBefore = new Metas($this->errorManager, [], ['name1' => $linkEntry1, 'name2' => $linkEntry2]);
+        $metasAfter  = new Metas($this->errorManager);
+
+        $loader = new CachedMetasLoader();
+        $loader->cacheMetaEntries($targetDir, $metasBefore);
+        $loader->loadCachedMetaEntries($targetDir, $metasAfter);
+        self::assertEquals(['name1' => $linkEntry1, 'name2' => $linkEntry2], $metasAfter->getLinkTargets());
     }
 }

--- a/tests/MetasTest.php
+++ b/tests/MetasTest.php
@@ -4,13 +4,23 @@ declare(strict_types=1);
 
 namespace Doctrine\Tests\RST;
 
+use Doctrine\RST\ErrorManager;
 use Doctrine\RST\Meta\LinkTarget;
 use Doctrine\RST\Meta\MetaEntry;
 use Doctrine\RST\Meta\Metas;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
 class MetasTest extends TestCase
 {
+    /** @var ErrorManager|MockObject */
+    private ErrorManager $errorManager;
+
+    protected function setUp(): void
+    {
+        $this->errorManager = $this->createMock(ErrorManager::class);
+    }
+
     public function testFindLinkMetaEntry(): void
     {
         $entry1 = new MetaEntry(
@@ -41,10 +51,13 @@ class MetasTest extends TestCase
             0
         );
 
-        $metas = new Metas([
-            $entry1,
-            $entry2,
-        ]);
+        $metas = new Metas(
+            $this->errorManager,
+            [
+                $entry1,
+                $entry2,
+            ]
+        );
 
         self::assertSame($entry1, $metas->findLinkTargetMetaEntry('link1'));
         self::assertSame($entry1, $metas->findLinkTargetMetaEntry('link2'));

--- a/tests/TextRoles/EnvironmentTest.php
+++ b/tests/TextRoles/EnvironmentTest.php
@@ -20,7 +20,7 @@ class EnvironmentTest extends TestCase
     {
         $configuration      = new Configuration();
         $this->errorManager = $this->createMock(ErrorManager::class);
-        $this->environment  = new Environment($configuration, $this->errorManager);
+        $this->environment  = new Environment($configuration, null, $this->errorManager);
     }
 
     public function testRegisterTextRole(): void


### PR DESCRIPTION
And warn about multiply defined link targets.

Right now anonymous links with the same title trigger warnings about duplicate link targets, this is resolved by https://github.com/doctrine/rst-parser/pull/231