### PR TITLE
[Feature] Replace interpreted text

### DIFF
--- a/lib/HTML/Renderers/SpanNodeRenderer.php
+++ b/lib/HTML/Renderers/SpanNodeRenderer.php
@@ -55,6 +55,11 @@ final class SpanNodeRenderer extends BaseSpanNodeRenderer
         return $this->templateRenderer->render('literal.html.twig', ['text' => $text]);
     }
 
+    public function interpretedText(string $text): string
+    {
+        return $this->templateRenderer->render('interpreted-text.html.twig', ['text' => $text]);
+    }
+
     /** @param mixed[] $attributes */
     public function link(?string $url, string $title, array $attributes = []): string
     {

--- a/lib/LaTeX/Renderers/SpanNodeRenderer.php
+++ b/lib/LaTeX/Renderers/SpanNodeRenderer.php
@@ -54,6 +54,11 @@ final class SpanNodeRenderer extends BaseSpanNodeRenderer
         return $this->templateRenderer->render('literal.tex.twig', ['text' => $text]);
     }
 
+    public function interpretedText(string $text): string
+    {
+        return $this->templateRenderer->render('interpreted-text.tex.twig', ['text' => $text]);
+    }
+
     /** @param mixed[] $attributes */
     public function link(?string $url, string $title, array $attributes = []): string
     {

--- a/lib/Renderers/SpanNodeRenderer.php
+++ b/lib/Renderers/SpanNodeRenderer.php
@@ -122,6 +122,9 @@ abstract class SpanNodeRenderer implements NodeRenderer, SpanRenderer
             case SpanToken::TYPE_LITERAL:
                 return $this->renderLiteral($spanToken, $span);
 
+            case SpanToken::TYPE_INTERPRETED:
+                return $this->renderInterpretedText($spanToken, $span);
+
             case SpanToken::TYPE_TEXT_ROLE:
                 return $this->renderTextNode($spanToken, $span);
 
@@ -137,6 +140,15 @@ abstract class SpanNodeRenderer implements NodeRenderer, SpanRenderer
         return str_replace(
             $spanToken->getId(),
             $this->literal($spanToken->get('text')),
+            $span
+        );
+    }
+
+    private function renderInterpretedText(SpanToken $spanToken, string $span): string
+    {
+        return str_replace(
+            $spanToken->getId(),
+            $this->interpretedText($spanToken->get('text')),
             $span
         );
     }

--- a/lib/Renderers/SpanRenderer.php
+++ b/lib/Renderers/SpanRenderer.php
@@ -18,6 +18,8 @@ interface SpanRenderer
 
     public function literal(string $text): string;
 
+    public function interpretedText(string $text): string;
+
     /** @param mixed[] $attributes */
     public function link(?string $url, string $title, array $attributes = []): string;
 

--- a/lib/Span/SpanProcessor.php
+++ b/lib/Span/SpanProcessor.php
@@ -49,6 +49,8 @@ final class SpanProcessor
     {
         $span = $this->replaceLiterals($this->span);
 
+        $span = $this->replaceInterpretedText($span);
+
         $span = $this->replaceTitleLetters($span);
 
         $span = $this->replaceTextRoles($span);
@@ -94,6 +96,24 @@ final class SpanProcessor
 
                 $this->addToken(SpanToken::TYPE_LITERAL, $id, [
                     'type' => 'literal',
+                    'text' => htmlspecialchars($match[1]),
+                ]);
+
+                return $id;
+            },
+            $span
+        );
+    }
+
+    private function replaceInterpretedText(string $span): string
+    {
+        return (string) preg_replace_callback(
+            '/(?<=^|\s)`(\S|\S\S|\S[^`]+\S)`(?!(:.+:|[_]))/mUsi',
+            function (array $match): string {
+                $id = $this->generateId();
+
+                $this->addToken(SpanToken::TYPE_INTERPRETED, $id, [
+                    'type' => SpanToken::TYPE_INTERPRETED,
                     'text' => htmlspecialchars($match[1]),
                 ]);
 

--- a/lib/Span/SpanToken.php
+++ b/lib/Span/SpanToken.php
@@ -6,9 +6,10 @@ namespace Doctrine\RST\Span;
 
 final class SpanToken
 {
-    public const TYPE_LITERAL   = 'literal';
-    public const TYPE_TEXT_ROLE = 'textrole';
-    public const TYPE_LINK      = 'link';
+    public const TYPE_LITERAL     = 'literal';
+    public const TYPE_INTERPRETED = 'interpreted';
+    public const TYPE_TEXT_ROLE   = 'textrole';
+    public const TYPE_LINK        = 'link';
 
     /** @var string */
     private $type;

--- a/lib/Templates/default/html/interpreted-text.html.twig
+++ b/lib/Templates/default/html/interpreted-text.html.twig
@@ -1,0 +1,1 @@
+<code>{{ text|raw }}</code>

--- a/lib/Templates/default/tex/interpreted-text.tex.twig
+++ b/lib/Templates/default/tex/interpreted-text.tex.twig
@@ -1,0 +1,1 @@
+\verb|{{ text|raw }}|

--- a/tests/Functional/tests/render/interpreted-text/interpreted-text.html
+++ b/tests/Functional/tests/render/interpreted-text/interpreted-text.html
@@ -1,0 +1,4 @@
+<p>Testing some <code>interpreted text</code>...</p>
+<p><code>a</code> or <code>aa</code> or <code>.\/$!</code></p>
+<p><code>This long interpreted text is longer
+    then one line</code></p>

--- a/tests/Functional/tests/render/interpreted-text/interpreted-text.html
+++ b/tests/Functional/tests/render/interpreted-text/interpreted-text.html
@@ -1,4 +1,4 @@
 <p>Testing some <code>interpreted text</code>...</p>
 <p><code>a</code> or <code>aa</code> or <code>.\/$!</code></p>
 <p><code>This long interpreted text is longer
-    then one line</code></p>
+    than one line</code></p>

--- a/tests/Functional/tests/render/interpreted-text/interpreted-text.rst
+++ b/tests/Functional/tests/render/interpreted-text/interpreted-text.rst
@@ -1,0 +1,6 @@
+Testing some `interpreted text`...
+
+`a` or `aa` or `.\/$!`
+
+`This long interpreted text is longer
+then one line`

--- a/tests/Functional/tests/render/interpreted-text/interpreted-text.rst
+++ b/tests/Functional/tests/render/interpreted-text/interpreted-text.rst
@@ -3,4 +3,4 @@ Testing some `interpreted text`...
 `a` or `aa` or `.\/$!`
 
 `This long interpreted text is longer
-then one line`
+than one line`


### PR DESCRIPTION
Interpreted text without explicit text role should be interpreted as default role.

In software projects the default role is usually code.

Right now these are interpreted as references that cannot be resolved causing warnings.

Compare https://docutils.sourceforge.io/docs/ref/rst/roles.html