### PR TITLE
[FEATURE] Add support for standard rst and sphinx text roles

### DIFF
--- a/lib/Environment.php
+++ b/lib/Environment.php
@@ -138,6 +138,9 @@ class Environment
     public function registerTextRole(TextRole $textRole): void
     {
         $this->textRoles[$textRole->getName()] = $textRole;
+        foreach ($textRole->getAliases() as $alias) {
+            $this->textRoles[trim(strtolower($alias))] = $textRole;
+        }
     }
 
     public function isReference(string $section): bool

--- a/lib/Formats/Format.php
+++ b/lib/Formats/Format.php
@@ -6,6 +6,7 @@ namespace Doctrine\RST\Formats;
 
 use Doctrine\RST\Directives\Directive;
 use Doctrine\RST\Renderers\NodeRendererFactory;
+use Doctrine\RST\TextRoles\TextRole;
 
 interface Format
 {
@@ -16,6 +17,9 @@ interface Format
 
     /** @return Directive[] */
     public function getDirectives(): array;
+
+    /** @return TextRole[] */
+    public function getTextRoles(): array;
 
     /** @return NodeRendererFactory[] */
     public function getNodeRendererFactories(): array;

--- a/lib/Formats/InternalFormat.php
+++ b/lib/Formats/InternalFormat.php
@@ -6,6 +6,7 @@ namespace Doctrine\RST\Formats;
 
 use Doctrine\RST\Directives\Directive;
 use Doctrine\RST\Renderers\NodeRendererFactory;
+use Doctrine\RST\TextRoles\TextRole;
 
 final class InternalFormat implements Format
 {
@@ -17,6 +18,9 @@ final class InternalFormat implements Format
 
     /** @var NodeRendererFactory[]|null */
     private $nodeRendererFactories;
+
+    /** @var TextRole[]|null */
+    private ?array $textRoles = null;
 
     public function __construct(Format $format)
     {
@@ -36,6 +40,16 @@ final class InternalFormat implements Format
         }
 
         return $this->directives;
+    }
+
+    /** @return TextRole[] */
+    public function getTextRoles(): array
+    {
+        if ($this->textRoles === null) {
+            $this->textRoles = $this->format->getTextRoles();
+        }
+
+        return $this->textRoles;
     }
 
     /** @return NodeRendererFactory[] */

--- a/lib/HTML/HTMLFormat.php
+++ b/lib/HTML/HTMLFormat.php
@@ -12,6 +12,9 @@ use Doctrine\RST\Renderers;
 use Doctrine\RST\Renderers\CallableNodeRendererFactory;
 use Doctrine\RST\Renderers\NodeRendererFactory;
 use Doctrine\RST\Templates\TemplateRenderer;
+use Doctrine\RST\TextRoles\DefinitionTextRole;
+use Doctrine\RST\TextRoles\TextRole;
+use Doctrine\RST\TextRoles\WrapperTextRole;
 
 final class HTMLFormat implements Format
 {
@@ -41,6 +44,28 @@ final class HTMLFormat implements Format
             new HTML\Directives\Div(),
             new HTML\Directives\Wrap('note'),
             new HTML\Directives\ClassDirective(),
+        ];
+    }
+
+    /** @return TextRole[] */
+    public function getTextRoles(): array
+    {
+        return [
+            new WrapperTextRole('aspect', '<em class="aspect">%s</em>'),
+            new WrapperTextRole('command', '<strong class="command">%s</strong>'),
+            new WrapperTextRole('dfn', '<em class="dfn">%s</em>'),
+            new WrapperTextRole('file', '<span class="pre file">%s</span>'),
+            new WrapperTextRole('guilabel', '<span class="guilabel">%s</span>'),
+            new WrapperTextRole('kbd', '<kbd class="kbd docutils literal notranslate">%s</kbd>'),
+            new WrapperTextRole('mailheader', '<em class="mailheader">%s</em>'),
+            new WrapperTextRole('math', '<math>%s</math>'),
+            new WrapperTextRole('emphasis', '<em>%s</em>'),
+            new WrapperTextRole('literal', '<span class="pre">%s</span>'),
+            new WrapperTextRole('strong', '<strong>%s</strong>'),
+            new WrapperTextRole('subscript', '<sub>%s</sub>', ['sub']),
+            new WrapperTextRole('superscript', '<sup>%s</sup>', ['sup']),
+            new WrapperTextRole('title-reference', '<cite>%s</cite>', ['t', 'title']),
+            new DefinitionTextRole('abbreviation', '<abbr title="%2$s">%1$s</abbr>', ['abbr']),
         ];
     }
 

--- a/lib/Kernel.php
+++ b/lib/Kernel.php
@@ -63,7 +63,7 @@ class Kernel
 
         $this->textRoles = array_merge([
             new TextRoles\CodeRole(),
-        ], $this->createTextRoles(), $textRoles);
+        ], $this->configuration->getFormat()->getTextRoles(), $this->createTextRoles(), $textRoles);
 
         $this->references = array_merge([
             new References\Doc(),

--- a/lib/LaTeX/LaTeXFormat.php
+++ b/lib/LaTeX/LaTeXFormat.php
@@ -12,6 +12,7 @@ use Doctrine\RST\Renderers;
 use Doctrine\RST\Renderers\CallableNodeRendererFactory;
 use Doctrine\RST\Renderers\NodeRendererFactory;
 use Doctrine\RST\Templates\TemplateRenderer;
+use Doctrine\RST\TextRoles\TextRole;
 
 final class LaTeXFormat implements Format
 {
@@ -40,6 +41,12 @@ final class LaTeXFormat implements Format
             new LaTeX\Directives\Url(),
             new LaTeX\Directives\Wrap('note'),
         ];
+    }
+
+    /** @return TextRole[] */
+    public function getTextRoles(): array
+    {
+        return [];
     }
 
     /** @return NodeRendererFactory[] */

--- a/lib/TextRoles/CodeRole.php
+++ b/lib/TextRoles/CodeRole.php
@@ -4,15 +4,10 @@ declare(strict_types=1);
 
 namespace Doctrine\RST\TextRoles;
 
-class CodeRole extends TextRole
+class CodeRole extends WrapperTextRole
 {
-    public function getName(): string
+    public function __construct()
     {
-        return 'code';
-    }
-
-    public function process(string $text): string
-    {
-        return '<code>' . $text . '</code>';
+        parent::__construct('code', '<code>%s</code>');
     }
 }

--- a/lib/TextRoles/DefinitionTextRole.php
+++ b/lib/TextRoles/DefinitionTextRole.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\RST\TextRoles;
+
+use function preg_match;
+use function sprintf;
+use function trim;
+
+/**
+ * A text role which wraps a text and optionally an additional definition in
+ * brackets. Can be used for abbreviations, tooltips, etc
+ *
+ * Example:
+ * ```
+ * :abbreviation:`LIFO (last-in, first-out)`
+ * ```
+ */
+class DefinitionTextRole extends TextRole
+{
+    private string $name;
+    private string $wrap;
+
+    /** @param string[] $aliases */
+    public function __construct(string $name, string $wrap, array $aliases = [])
+    {
+        $this->name = $name;
+        $this->wrap = $wrap;
+        $this->setAliases($aliases);
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function process(string $text): string
+    {
+        $definition = '';
+        if (preg_match('/(.+)\(([^\)]+)\)$/', $text, $matches) !== 0) {
+            $text       =  trim($matches[1]);
+            $definition = trim($matches[2]);
+        }
+
+        return sprintf($this->wrap, $text, $definition);
+    }
+}

--- a/lib/TextRoles/TextRole.php
+++ b/lib/TextRoles/TextRole.php
@@ -15,6 +15,21 @@ namespace Doctrine\RST\TextRoles;
  */
 abstract class TextRole
 {
+    /** @var String[] */
+    protected array $aliases = [];
+
+    /** @return String[] */
+    public function getAliases(): array
+    {
+        return $this->aliases;
+    }
+
+    /** @param String[] $aliases */
+    public function setAliases(array $aliases): void
+    {
+        $this->aliases = $aliases;
+    }
+
     /**
      * The name of the reference, i.e the :something:
      */

--- a/lib/TextRoles/WrapperTextRole.php
+++ b/lib/TextRoles/WrapperTextRole.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\RST\TextRoles;
+
+use function sprintf;
+
+class WrapperTextRole extends TextRole
+{
+    private string $name;
+    private string $wrap;
+
+    /**
+     * @param string   $wrap    A sprintf string containing one marker for the text
+     * @param String[] $aliases Aliases for the name
+     */
+    public function __construct(string $name, string $wrap, array $aliases = [])
+    {
+        $this->name = $name;
+        $this->wrap = $wrap;
+        $this->setAliases($aliases);
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function process(string $text): string
+    {
+        return sprintf($this->wrap, $text);
+    }
+}

--- a/tests/Functional/tests/render/text-roles/text-roles.html
+++ b/tests/Functional/tests/render/text-roles/text-roles.html
@@ -1,1 +1,20 @@
+<p><code>Default interpreted text</code></p>
 <p><code>Lorem Ipsum</code></p>
+<p><abbr title="last-in, first-out">LIFO</abbr></p>
+<p><em class="aspect">Some important aspect</em></p>
+<p><code>result = (1 + x) * 32</code></p>
+<p><strong class="command">rm</strong></p>
+<p><em class="dfn">something</em></p>
+<p><span class="pre file">/etc/passwd</span></p>
+<p><span class="guilabel">&Cancel</span></p>
+<p>Press <kbd class="kbd docutils literal notranslate">ctrl</kbd> + <kbd class="kbd docutils literal notranslate">s</kbd></p>
+<p><em class="mailheader">Content-Type</em></p>
+<p>
+    <math>A_\text{c} = (\pi/4) d^2</math>
+    </p>
+<p><em>text</em></p>
+<p><span class="pre">abc</span></p>
+<p><strong>text</strong>, <strong>text</strong></p>
+<p><sub>subscripted</sub>, <sub>sub</sub></p>
+<p><sub>superscript</sub>, <sub>sup</sub></p>
+<p><cite>Design Patterns</cite>, <cite>Design Patterns</cite>, :title-reference:`Design Patterns`</p>

--- a/tests/Functional/tests/render/text-roles/text-roles.rst
+++ b/tests/Functional/tests/render/text-roles/text-roles.rst
@@ -1,1 +1,35 @@
+`Default interpreted text`
+
 :code:`Lorem Ipsum`
+
+:abbreviation:`LIFO (last-in, first-out)`
+
+:aspect:`Some important aspect`
+
+:code:`result = (1 + x) * 32`
+
+:command:`rm`
+
+:dfn:`something`
+
+:file:`/etc/passwd`
+
+:guilabel:`&Cancel`
+
+Press :kbd:`ctrl` + :kbd:`s`
+
+:mailheader:`Content-Type`
+
+:math:`A_\text{c} = (\pi/4) d^2`
+
+:emphasis:`text`
+
+:literal:`abc`
+
+:strong:`text`, **text**
+
+:subscript:`subscripted`, :sub:`sub`
+
+:subscript:`superscript`, :sub:`sup`
+
+:t:`Design Patterns`, :title:`Design Patterns`, :title-reference:`Design Patterns`


### PR DESCRIPTION
Make standard wrapper text roles that only need to be instantiated, add example HTML markup. Allow textrole registration by Format

resolves #78

See https://docs.typo3.org/m/typo3/docs-how-to-document/main/en-us/WritingReST/Reference/Code/InlineCode.html

https://docutils.sourceforge.io/docs/ref/rst/roles.html#toc-entry-3