### PR TITLE
[FEATURE] Introduce Pre and Post rendering document events

### DIFF
--- a/docs/en/events.rst
+++ b/docs/en/events.rst
@@ -79,7 +79,7 @@ The events you can listen for are as follows:
   in implementing projects or extending packages. See
   `Package Intersphinx, provided by the TYPO3 Documentation Team <https://github.com/TYPO3-Documentation/intersphinx>`__
   for an example implementation.
-- ``PreDocumentRenderEvent``: This event is called in the DocumentNodeRenderer
+- ``PreDocumentRenderEvent``: This event is called in the `DocumentNodeRenderer`
   before the document Node is rendered. The event can be used to influence the
   parameters sent to the template and or the name of the template to be used
   during rendering.

--- a/docs/en/events.rst
+++ b/docs/en/events.rst
@@ -83,7 +83,7 @@ The events you can listen for are as follows:
   before the document Node is rendered. The event can be used to influence the
   parameters sent to the template and or the name of the template to be used
   during rendering.
-- ``PostDocumentRenderEvent``: This event is called in the DocumentNodeRenderer
+- ``PostDocumentRenderEvent``: This event is called in the `DocumentNodeRenderer`
   after the content of the document got rendered and before the HTML is
   returned. It can be used to postprocess or exchange the HTML that will be
   written to the file.

--- a/docs/en/events.rst
+++ b/docs/en/events.rst
@@ -79,3 +79,11 @@ The events you can listen for are as follows:
   in implementing projects or extending packages. See
   `Package Intersphinx, provided by the TYPO3 Documentation Team <https://github.com/TYPO3-Documentation/intersphinx>`__
   for an example implementation.
+- ``PreDocumentRenderEvent``: This event is called in the DocumentNodeRenderer
+  before the document Node is rendered. The event can be used to influence the
+  parameters sent to the template and or the name of the template to be used
+  during rendering.
+- ``PostDocumentRenderEvent``: This event is called in the DocumentNodeRenderer
+  after the content of the document got rendered and before the HTML is
+  returned. It can be used to postprocess or exchange the HTML that will be
+  written to the file.

--- a/lib/Event/PostDocumentRenderEvent.php
+++ b/lib/Event/PostDocumentRenderEvent.php
@@ -14,7 +14,7 @@ use function sprintf;
 /**
  * This event is called in the DocumentNodeRenderer after the content of
  * the document got rendered and before the HTML is returned. It can be used
- * to postprocess or exchange the HTML that will be written to the file.
+ * to postprocess or change the HTML that will be written to the file.
  */
 final class PostDocumentRenderEvent extends EventArgs
 {

--- a/lib/Event/PostDocumentRenderEvent.php
+++ b/lib/Event/PostDocumentRenderEvent.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\RST\Event;
+
+use Doctrine\Common\EventArgs;
+use Doctrine\RST\Configuration;
+use Doctrine\RST\Nodes\DocumentNode;
+use Doctrine\RST\Templates\TemplateRenderer;
+
+use function sprintf;
+
+/**
+ * This event is called in the DocumentNodeRenderer after the content of
+ * the document got rendered and before the HTML is returned. It can be used
+ * to postprocess or exchange the HTML that will be written to the file.
+ */
+final class PostDocumentRenderEvent extends EventArgs
+{
+    public const POST_DOCUMENT_RENDER = 'postDocumentRender';
+
+    private Configuration $configuration;
+    private DocumentNode $documentNode;
+    private TemplateRenderer $templateRenderer;
+    private string $html;
+    /** @var array<string, mixed>  */
+    private array $parameters;
+    private string $templateName;
+
+    /** @param array<string, mixed> $parameters */
+    public function __construct(
+        Configuration $configuration,
+        DocumentNode $documentNode,
+        TemplateRenderer $templateRenderer,
+        string $html,
+        array $parameters,
+        string $templateName = 'document.%s.twig'
+    ) {
+        $this->configuration    = $configuration;
+        $this->documentNode     = $documentNode;
+        $this->templateRenderer = $templateRenderer;
+        $this->html             = $html;
+        $this->parameters       = $parameters;
+        $this->templateName     = sprintf($templateName, $this->configuration->getFileExtension());
+    }
+
+    public function getConfiguration(): Configuration
+    {
+        return $this->configuration;
+    }
+
+    public function getDocumentNode(): DocumentNode
+    {
+        return $this->documentNode;
+    }
+
+    public function getTemplateRenderer(): TemplateRenderer
+    {
+        return $this->templateRenderer;
+    }
+
+    public function getHtml(): string
+    {
+        return $this->html;
+    }
+
+    /** @return array<string, mixed> */
+    public function getParameters(): array
+    {
+        return $this->parameters;
+    }
+
+    public function getTemplateName(): string
+    {
+        return $this->templateName;
+    }
+
+    public function setHtml(string $html): void
+    {
+        $this->html = $html;
+    }
+}

--- a/lib/Event/PreDocumentRenderEvent.php
+++ b/lib/Event/PreDocumentRenderEvent.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\RST\Event;
+
+use Doctrine\Common\EventArgs;
+use Doctrine\RST\Configuration;
+use Doctrine\RST\Nodes\DocumentNode;
+
+use function sprintf;
+
+/**
+ * This event is called in the DocumentNodeRenderer before the document Node is
+ * rendered. The event can be used to influence the parameters sent to the
+ * template and or the template name.
+ */
+final class PreDocumentRenderEvent extends EventArgs
+{
+    public const PRE_DOCUMENT_RENDER = 'preDocumentRender';
+
+    private Configuration $configuration;
+    private DocumentNode $documentNode;
+    /** @var array|mixed[]  */
+    private array $parameters;
+    private string $templateName;
+
+    /** @param array<string, mixed> $parameters */
+    public function __construct(
+        Configuration $configuration,
+        DocumentNode $documentNode,
+        array $parameters,
+        string $templateName = 'document.%s.twig'
+    ) {
+        $this->configuration = $configuration;
+        $this->documentNode  = $documentNode;
+        $this->parameters    = $parameters;
+        $this->templateName  = sprintf($templateName, $this->configuration->getFileExtension());
+    }
+
+    public function getConfiguration(): Configuration
+    {
+        return $this->configuration;
+    }
+
+    public function getDocumentNode(): DocumentNode
+    {
+        return $this->documentNode;
+    }
+
+    /** @return array<string, mixed> */
+    public function getParameters(): array
+    {
+        return $this->parameters;
+    }
+
+    public function getTemplateName(): string
+    {
+        return $this->templateName;
+    }
+
+    /** @param array<string, mixed> $parameters */
+    public function setParameters(array $parameters): void
+    {
+        $this->parameters = $parameters;
+    }
+
+    public function setTemplateName(string $templateName): void
+    {
+        $this->templateName = $templateName;
+    }
+}

--- a/tests/DocumentRenderEvents/DocumentNodeRendererTest.php
+++ b/tests/DocumentRenderEvents/DocumentNodeRendererTest.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\RST\DocumentRenderEvents;
+
+use Doctrine\Common\EventManager;
+use Doctrine\RST\Configuration;
+use Doctrine\RST\Event\PostDocumentRenderEvent;
+use Doctrine\RST\Event\PreDocumentRenderEvent;
+use Doctrine\RST\HTML\Renderers\DocumentNodeRenderer;
+use Doctrine\RST\Nodes\DocumentNode;
+use Doctrine\RST\Templates\TemplateRenderer;
+use Doctrine\Tests\RST\DocumentRenderEvents\Listener\DocumentRenderListener;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+use function PHPUnit\Framework\assertEquals;
+
+class DocumentNodeRendererTest extends TestCase
+{
+    /** @var Configuration|MockObject */
+    private $configuration;
+    /** @var DocumentNode|MockObject */
+    private $document;
+    /** @var TemplateRenderer|MockObject */
+    private $templateRenderer;
+
+    protected function setUp(): void
+    {
+        $this->configuration    = $this->createMock(Configuration::class);
+        $this->document         = $this->createMock(DocumentNode::class);
+        $this->templateRenderer = $this->createMock(TemplateRenderer::class);
+        $this->document->method('getConfiguration')->willReturn($this->configuration);
+    }
+
+    public function testPreDocumentRenderEventOverridesTemplateNameAndParameters(): void
+    {
+        $template     = 'abc.html.twig';
+        $parameter    = ['a' => 'bc'];
+        $eventManager = new EventManager();
+        $eventManager->addEventListener(
+            [PreDocumentRenderEvent::PRE_DOCUMENT_RENDER],
+            new DocumentRenderListener(
+                $template,
+                $parameter,
+                ''
+            )
+        );
+        $subject = new DocumentNodeRenderer($this->document, $this->templateRenderer, $eventManager);
+        $this->templateRenderer
+            ->expects(self::once())->method('render')
+            ->with($template, $parameter);
+        $subject->renderDocument();
+    }
+
+    public function testPostDocumentRenderEventOverridesHtml(): void
+    {
+        $html         = '<p>Lorem Ipsum</p>';
+        $eventManager = new EventManager();
+        $eventManager->addEventListener(
+            [PostDocumentRenderEvent::POST_DOCUMENT_RENDER],
+            new DocumentRenderListener(
+                '',
+                [],
+                $html
+            )
+        );
+        $subject = new DocumentNodeRenderer($this->document, $this->templateRenderer, $eventManager);
+        $result  = $subject->renderDocument();
+        assertEquals($html, $result);
+    }
+}

--- a/tests/DocumentRenderEvents/Listener/DocumentRenderListener.php
+++ b/tests/DocumentRenderEvents/Listener/DocumentRenderListener.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\RST\DocumentRenderEvents\Listener;
+
+use Doctrine\RST\Event\PostDocumentRenderEvent;
+use Doctrine\RST\Event\PreDocumentRenderEvent;
+
+class DocumentRenderListener
+{
+    private string $templateName;
+    /** @var array<string, string> */
+    private array $parameters;
+    private string $html;
+
+    /** @param string[] $parameters */
+    public function __construct(
+        string $templateName,
+        array $parameters,
+        string $html
+    ) {
+        $this->templateName = $templateName;
+        $this->parameters   = $parameters;
+        $this->html         = $html;
+    }
+
+    public function preDocumentRender(PreDocumentRenderEvent $event): void
+    {
+        $event->setTemplateName($this->templateName);
+        $event->setParameters($this->parameters);
+    }
+
+    public function postDocumentRender(PostDocumentRenderEvent $event): void
+    {
+        $event->setHtml($this->html);
+    }
+}


### PR DESCRIPTION
I am using the pre event to pass additional information, for example the menu structure to my template. The post event could be used for post processing for example.
