### PR TITLE
[TASK] Refactor Error Management

### DIFF
--- a/lib/Builder.php
+++ b/lib/Builder.php
@@ -28,11 +28,7 @@ final class Builder
     /** @var Kernel */
     private $kernel;
 
-    /** @var Configuration */
-    private $configuration;
-
-    /** @var ErrorManager */
-    private $errorManager;
+    private Configuration $configuration;
 
     /** @var Filesystem */
     private $filesystem;
@@ -55,17 +51,15 @@ final class Builder
     /** @var string */
     private $indexName = 'index';
 
-    public function __construct(?Kernel $kernel = null, ?ErrorManager $errorManager = null)
+    public function __construct(Configuration $configuration, ?Kernel $kernel = null)
     {
-        $this->kernel = $kernel ?? new Kernel();
+        $this->configuration = $configuration;
 
-        $this->configuration = $this->kernel->getConfiguration();
-
-        $this->errorManager = $errorManager ?? new ErrorManager($this->configuration);
+        $this->kernel = $kernel ?? new Kernel($this->configuration);
 
         $this->filesystem = new Filesystem();
 
-        $this->metas = new Metas($this->errorManager);
+        $this->metas = new Metas($this->configuration);
 
         $this->cachedMetasLoader = new CachedMetasLoader();
 
@@ -81,7 +75,7 @@ final class Builder
 
     public function recreate(): Builder
     {
-        return new Builder($this->kernel);
+        return new Builder($this->configuration, $this->kernel);
     }
 
     public function getKernel(): Kernel
@@ -97,11 +91,6 @@ final class Builder
     public function getDocuments(): Documents
     {
         return $this->documents;
-    }
-
-    public function getErrorManager(): ErrorManager
-    {
-        return $this->errorManager;
     }
 
     public function setIndexName(string $name): self
@@ -202,8 +191,8 @@ final class Builder
         );
 
         $parseQueueProcessor = new ParseQueueProcessor(
+            $this->configuration,
             $this->kernel,
-            $this->errorManager,
             $this->metas,
             $this->documents,
             $directory,

--- a/lib/Builder/ParseQueueProcessor.php
+++ b/lib/Builder/ParseQueueProcessor.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\RST\Builder;
 
-use Doctrine\RST\ErrorManager;
+use Doctrine\RST\Configuration;
 use Doctrine\RST\Kernel;
 use Doctrine\RST\Meta\Metas;
 use Doctrine\RST\Nodes\DocumentNode;
@@ -20,11 +20,10 @@ use const STDERR;
 
 final class ParseQueueProcessor
 {
+    private Configuration $configuration;
+
     /** @var Kernel */
     private $kernel;
-
-    /** @var ErrorManager */
-    private $errorManager;
 
     /** @var Metas */
     private $metas;
@@ -42,16 +41,16 @@ final class ParseQueueProcessor
     private $fileExtension;
 
     public function __construct(
+        Configuration $configuration,
         Kernel $kernel,
-        ErrorManager $errorManager,
         Metas $metas,
         Documents $documents,
         string $directory,
         string $targetDirectory,
         string $fileExtension
     ) {
+        $this->configuration   = $configuration;
         $this->kernel          = $kernel;
-        $this->errorManager    = $errorManager;
         $this->metas           = $metas;
         $this->documents       = $documents;
         $this->directory       = $directory;
@@ -98,14 +97,13 @@ final class ParseQueueProcessor
 
     private function createFileParser(string $file): Parser
     {
-        $parser = new Parser($this->kernel);
+        $parser = new Parser($this->configuration, $this->kernel);
 
         $environment = $parser->getEnvironment();
         $environment->setMetas($this->metas);
         $environment->setCurrentFileName($file);
         $environment->setCurrentDirectory($this->directory);
         $environment->setTargetDirectory($this->targetDirectory);
-        $environment->setErrorManager($this->errorManager);
 
         return $parser;
     }

--- a/lib/Configuration.php
+++ b/lib/Configuration.php
@@ -6,6 +6,8 @@ namespace Doctrine\RST;
 
 use Doctrine\Common\EventArgs;
 use Doctrine\Common\EventManager;
+use Doctrine\RST\ErrorManager\DefaultErrorManagerFactory;
+use Doctrine\RST\ErrorManager\ErrorManagerFactory;
 use Doctrine\RST\Formats\Format;
 use Doctrine\RST\Formats\InternalFormat;
 use Doctrine\RST\HTML\HTMLFormat;
@@ -91,6 +93,8 @@ class Configuration
     /** @var TemplateEngineAdapter */
     private $templateEngineAdapter;
 
+    private ErrorManagerFactory $errorManagerFactory;
+
     public function __construct()
     {
         $this->cacheDir = sys_get_temp_dir() . '/doctrine-rst-parser';
@@ -99,6 +103,7 @@ class Configuration
 
         $this->templateEngineAdapter = new TwigAdapter($this);
         $this->templateRenderer      = new TwigTemplateRenderer($this);
+        $this->errorManagerFactory   = new DefaultErrorManagerFactory($this);
 
         $this->formats = [
             Format::HTML => new InternalFormat(new HTMLFormat($this->templateRenderer)),
@@ -378,5 +383,20 @@ class Configuration
     private function getNodeRendererFactory(string $nodeClassName): ?NodeRendererFactory
     {
         return $this->getFormat()->getNodeRendererFactories()[$nodeClassName] ?? null;
+    }
+
+    public function getErrorManagerFactory(): ErrorManagerFactory
+    {
+        return $this->errorManagerFactory;
+    }
+
+    public function setErrorManagerFactory(ErrorManagerFactory $errorManagerFactory): void
+    {
+        $this->errorManagerFactory = $errorManagerFactory;
+    }
+
+    public function getErrorManager(): ErrorManager
+    {
+        return $this->errorManagerFactory->getErrorManager();
     }
 }

--- a/lib/Environment.php
+++ b/lib/Environment.php
@@ -85,14 +85,14 @@ class Environment
     /** @var InvalidLink[] */
     private $invalidLinks = [];
 
-    public function __construct(Configuration $configuration, ?Metas $metas = null, ?ErrorManager $errorManager = null)
+    public function __construct(Configuration $configuration, ?Metas $metas = null)
     {
         $this->configuration = $configuration;
-        $this->errorManager  = $errorManager ?? new ErrorManager($this->configuration);
+        $this->errorManager  = $configuration->getErrorManager();
         $this->urlGenerator  = new UrlGenerator(
             $this->configuration
         );
-        $this->metas         = $metas ?? new Metas($this->errorManager);
+        $this->metas         = $metas ?? new Metas($this->configuration);
 
         $this->reset();
     }
@@ -113,16 +113,6 @@ class Environment
     public function getConfiguration(): Configuration
     {
         return $this->configuration;
-    }
-
-    public function getErrorManager(): ErrorManager
-    {
-        return $this->errorManager;
-    }
-
-    public function setErrorManager(ErrorManager $errorManager): void
-    {
-        $this->errorManager = $errorManager;
     }
 
     public function setMetas(Metas $metas): void

--- a/lib/Error.php
+++ b/lib/Error.php
@@ -10,6 +10,11 @@ use function sprintf;
 
 final class Error
 {
+    public const LEVEL_ERROR   = 'error';
+    public const LEVEL_WARNING = 'warning';
+
+    private string $level;
+
     /** @var string */
     private $message;
 
@@ -22,8 +27,9 @@ final class Error
     /** @var Throwable|null */
     private $throwable;
 
-    public function __construct(string $message, ?string $file = null, ?int $line = null, ?Throwable $throwable = null)
+    public function __construct(string $level, string $message, ?string $file = null, ?int $line = null, ?Throwable $throwable = null)
     {
+        $this->level     = $level;
         $this->message   = $message;
         $this->file      = $file;
         $this->line      = $line;
@@ -42,6 +48,16 @@ final class Error
         }
 
         return $output;
+    }
+
+    public function getLevel(): string
+    {
+        return $this->level;
+    }
+
+    public function setLevel(string $level): void
+    {
+        $this->level = $level;
     }
 
     public function getMessage(): string

--- a/lib/ErrorManager.php
+++ b/lib/ErrorManager.php
@@ -4,76 +4,24 @@ declare(strict_types=1);
 
 namespace Doctrine\RST;
 
-use Exception;
 use Throwable;
 
-use function sprintf;
-
-class ErrorManager
+interface ErrorManager
 {
-    /** @var Configuration */
-    private $configuration;
+    public function error(
+        string $message,
+        ?string $file = null,
+        ?int $line = null,
+        ?Throwable $throwable = null
+    ): void;
 
-    /** @var list<Error> */
-    private $errors = [];
-
-    public function __construct(Configuration $configuration)
-    {
-        $this->configuration = $configuration;
-    }
-
-    public function error(string $message, ?string $file = null, ?int $line = null, ?Throwable $throwable = null): void
-    {
-        $this->errors[] = $error = new Error($message, $file, $line, $throwable);
-
-        if (! $this->configuration->isSilentOnError()) {
-            if ($this->configuration->getOutputFormat() === Configuration::OUTPUT_FORMAT_GITHUB) {
-                $file = $error->getFile();
-                echo sprintf(
-                    '::error %s%s::%s',
-                    $file !== null ? 'file=' . $file : '',
-                    $file !== null && $error->getLine() !== null ? ',linefile=' . $error->getLine() : '',
-                    $error->getMessage()
-                );
-            } else {
-                echo '⚠️ ' . $error->asString() . "\n";
-            }
-        }
-
-        if ($this->configuration->isAbortOnError()) {
-            throw new Exception($error->asString(), 0, $error->getThrowable());
-        }
-    }
-
-    public function warning(string $message, ?string $file = null, ?int $line = null, ?Throwable $throwable = null): void
-    {
-        if ($this->configuration->isWarningsAsError()) {
-            $this->error($message, $file, $line, $throwable);
-
-            return;
-        }
-
-        if ($this->configuration->isSilentOnError()) {
-            return;
-        }
-
-        $error = new Error($message, $file, $line, $throwable);
-        if ($this->configuration->getOutputFormat() === Configuration::OUTPUT_FORMAT_GITHUB) {
-            $file = $error->getFile();
-            echo sprintf(
-                '::warning %s%s::%s',
-                $file !== null ? 'file=' . $file : '',
-                $file !== null && $error->getLine() !== null ? ',linefile=' . $error->getLine() : '',
-                $error->getMessage()
-            );
-        } else {
-            echo $error->asString() . "\n";
-        }
-    }
+    public function warning(
+        string $message,
+        ?string $file = null,
+        ?int $line = null,
+        ?Throwable $throwable = null
+    ): void;
 
     /** @return list<Error> */
-    public function getErrors(): array
-    {
-        return $this->errors;
-    }
+    public function getErrors(): array;
 }

--- a/lib/ErrorManager/DefaultErrorManager.php
+++ b/lib/ErrorManager/DefaultErrorManager.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\RST\ErrorManager;
+
+use Doctrine\RST\Configuration;
+use Doctrine\RST\Error;
+use Doctrine\RST\ErrorManager;
+use Exception;
+use Throwable;
+
+use function sprintf;
+
+final class DefaultErrorManager implements ErrorManager
+{
+    /** @var Configuration */
+    private $configuration;
+
+    /** @var list<Error> */
+    private $errors = [];
+
+    public function __construct(Configuration $configuration)
+    {
+        $this->configuration = $configuration;
+    }
+
+    private function log(string $level, string $message, ?string $file = null, ?int $line = null, ?Throwable $throwable = null): void
+    {
+        $this->errors[] = $error = new Error($level, $message, $file, $line, $throwable);
+        if (! $this->configuration->isSilentOnError()) {
+            if ($level === Error::LEVEL_WARNING && $this->configuration->isWarningsAsError()) {
+                $level = Error::LEVEL_ERROR;
+            }
+
+            if ($this->configuration->getOutputFormat() === Configuration::OUTPUT_FORMAT_GITHUB) {
+                $file = $error->getFile();
+                echo sprintf(
+                    '::%s %s%s::%s',
+                    $level,
+                    $file !== null ? 'file=' . $file : '',
+                    $file !== null && $error->getLine() !== null ? ',linefile=' . $error->getLine() : '',
+                    $error->getMessage()
+                );
+            } else {
+                echo ($level === Error::LEVEL_ERROR ? '⚡️ ' : '⚠️ ') . $error->asString() . "\n";
+            }
+        }
+
+        if ($level === Error::LEVEL_ERROR && $this->configuration->isAbortOnError()) {
+            throw new Exception($error->asString(), 0, $error->getThrowable());
+        }
+    }
+
+    public function error(string $message, ?string $file = null, ?int $line = null, ?Throwable $throwable = null): void
+    {
+        $this->log(Error::LEVEL_ERROR, $message, $file, $line, $throwable);
+    }
+
+    public function warning(string $message, ?string $file = null, ?int $line = null, ?Throwable $throwable = null): void
+    {
+        $this->log(Error::LEVEL_WARNING, $message, $file, $line, $throwable);
+    }
+
+    /** @return list<Error> */
+    public function getErrors(): array
+    {
+        return $this->errors;
+    }
+}

--- a/lib/ErrorManager/DefaultErrorManagerFactory.php
+++ b/lib/ErrorManager/DefaultErrorManagerFactory.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\RST\ErrorManager;
+
+use Doctrine\RST\Configuration;
+use Doctrine\RST\ErrorManager;
+
+final class DefaultErrorManagerFactory implements ErrorManagerFactory
+{
+    private ?ErrorManager $errorManager = null;
+    private Configuration $configuration;
+
+    public function __construct(Configuration $configuration)
+    {
+        $this->configuration = $configuration;
+    }
+
+    public function getErrorManager(): ErrorManager
+    {
+        if ($this->errorManager === null) {
+            $this->errorManager = new DefaultErrorManager($this->configuration);
+        }
+
+        return $this->errorManager;
+    }
+}

--- a/lib/ErrorManager/ErrorManagerFactory.php
+++ b/lib/ErrorManager/ErrorManagerFactory.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\RST\ErrorManager;
+
+use Doctrine\RST\ErrorManager;
+
+interface ErrorManagerFactory
+{
+    public function getErrorManager(): ErrorManager;
+}

--- a/lib/Meta/Metas.php
+++ b/lib/Meta/Metas.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\RST\Meta;
 
+use Doctrine\RST\Configuration;
 use Doctrine\RST\Environment;
 use Doctrine\RST\ErrorManager;
 use Doctrine\RST\UrlGenerator;
@@ -26,17 +27,19 @@ class Metas
     /** @var array<string, LinkTarget> */
     private array $linkTargets = [];
 
+    private Configuration $configuration;
     private ErrorManager $errorManager;
 
     /**
      * @param MetaEntry[]               $entries
      * @param array<string, LinkTarget> $linkTargets
      */
-    public function __construct(ErrorManager $errorManager, array $entries = [], array $linkTargets = [])
+    public function __construct(Configuration $configuration, array $entries = [], array $linkTargets = [])
     {
-        $this->errorManager = $errorManager;
-        $this->entries      = $entries;
-        $this->linkTargets  = $linkTargets;
+        $this->configuration = $configuration;
+        $this->errorManager  = $this->configuration->getErrorManager();
+        $this->entries       = $entries;
+        $this->linkTargets   = $linkTargets;
     }
 
     public function findLinkTargetMetaEntry(string $linkTarget): ?MetaEntry

--- a/lib/Nodes/DocumentNode.php
+++ b/lib/Nodes/DocumentNode.php
@@ -39,7 +39,7 @@ class DocumentNode extends Node
 
         $this->environment   = $environment;
         $this->configuration = $environment->getConfiguration();
-        $this->errorManager  = $environment->getErrorManager();
+        $this->errorManager  = $this->configuration->getErrorManager();
     }
 
     public function getEnvironment(): Environment

--- a/lib/Nodes/TableNode.php
+++ b/lib/Nodes/TableNode.php
@@ -149,7 +149,7 @@ class TableNode extends Node
         $tableAsString = $this->getTableAsString();
 
         if (count($this->errors) > 0) {
-            $parser->getEnvironment()
+            $parser->getEnvironment()->getConfiguration()
                 ->getErrorManager()
                 ->error(sprintf("%s\n\n%s", $this->errors[0], $tableAsString), $parser->getFilename());
 

--- a/lib/Parser.php
+++ b/lib/Parser.php
@@ -23,8 +23,7 @@ use const STDERR;
 
 class Parser
 {
-    /** @var Configuration */
-    private $configuration;
+    private Configuration $configuration;
 
     /** @var Kernel */
     private $kernel;
@@ -48,6 +47,7 @@ class Parser
     private $documentParser;
 
     public function __construct(
+        Configuration $configuration,
         ?Kernel $kernel = null,
         ?Environment $environment = null
     ) {
@@ -55,7 +55,7 @@ class Parser
             $kernel = new Kernel();
         }
 
-        $this->configuration = $kernel->getConfiguration();
+        $this->configuration = $configuration;
         $this->kernel        = $kernel;
         $this->environment   = $environment ??  new Environment($this->configuration);
 
@@ -66,7 +66,7 @@ class Parser
 
     public function getSubParser(): Parser
     {
-        return new Parser($this->kernel, $this->environment);
+        return new Parser($this->configuration, $this->kernel, $this->environment);
     }
 
     public function getNodeFactory(): NodeFactory
@@ -216,6 +216,7 @@ class Parser
     private function createDocumentParser(): DocumentParser
     {
         return new DocumentParser(
+            $this->configuration,
             $this,
             $this->environment,
             $this->getNodeFactory(),

--- a/tests/BaseBuilderTest.php
+++ b/tests/BaseBuilderTest.php
@@ -6,25 +6,23 @@ namespace Doctrine\Tests\RST;
 
 use Doctrine\RST\Builder;
 use Exception;
-use PHPUnit\Framework\TestCase;
 
 use function file_get_contents;
 use function shell_exec;
 
-abstract class BaseBuilderTest extends TestCase
+abstract class BaseBuilderTest extends BaseTest
 {
-    /** @var Builder */
-    protected $builder;
+    protected Builder $builder;
 
     abstract protected function getFixturesDirectory(): string;
 
     protected function setUp(): void
     {
+        parent::setUp();
         shell_exec('rm -rf ' . $this->targetFile());
-
-        $this->builder = new Builder();
-        $this->builder->getConfiguration()->setUseCachedMetas(false);
+        $this->builder = new Builder($this->configuration);
         $this->configureBuilder($this->builder);
+        // build must be executed
         $this->builder->build($this->sourceFile(), $this->targetFile());
     }
 

--- a/tests/BaseTest.php
+++ b/tests/BaseTest.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\RST;
+
+use Doctrine\RST\Configuration;
+use Doctrine\RST\ErrorManager;
+use Doctrine\RST\ErrorManager\ErrorManagerFactory;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+abstract class BaseTest extends TestCase
+{
+    protected Configuration $configuration;
+    /** @var ErrorManager|MockObject */
+    protected ErrorManager $errorManager;
+
+    protected function setUp(): void
+    {
+        $this->configuration = new Configuration();
+        $this->configuration->setUseCachedMetas(false);
+        $this->errorManager  = $this->createMock(ErrorManager::class);
+        $errorManagerFactory = $this->createMock(ErrorManagerFactory::class);
+        $this->configuration->setErrorManagerFactory($errorManagerFactory);
+        $errorManagerFactory->method('getErrorManager')->willReturn($this->errorManager);
+        $this->configureExpectedWarnings();
+        $this->configureExpectedErrors();
+    }
+
+    /**
+     * We expect no warnings to occur during the build. If you want to test
+     * expected warnings to be found, override this method.
+     */
+    protected function configureExpectedWarnings(): void
+    {
+        $this->errorManager->expects(self::never())->method('warning');
+    }
+
+    /**
+     * We expect no errors to occur during the build. If you want to test
+     * expected errors to be found, override this method.
+     */
+    protected function configureExpectedErrors(): void
+    {
+        $this->errorManager->expects(self::never())->method('error');
+    }
+}

--- a/tests/Builder/BuilderTest.php
+++ b/tests/Builder/BuilderTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\Tests\RST\Builder;
 
 use Doctrine\RST\Builder;
+use Doctrine\RST\Configuration;
 use Doctrine\Tests\RST\BaseBuilderTest;
 use Symfony\Component\DomCrawler\Crawler;
 
@@ -104,7 +105,7 @@ class BuilderTest extends BaseBuilderTest
         );
 
         // new builder, which will use cached metas
-        $builder = new Builder();
+        $builder = new Builder(new Configuration());
         $builder->build($this->sourceFile(), $this->targetFile());
 
         $contents = $this->getFileContents($this->targetFile('link-to-index.html'));

--- a/tests/Builder/ParseQueueProcessorTest.php
+++ b/tests/Builder/ParseQueueProcessorTest.php
@@ -7,7 +7,7 @@ namespace Doctrine\Tests\RST\Builder;
 use Doctrine\RST\Builder\Documents;
 use Doctrine\RST\Builder\ParseQueue;
 use Doctrine\RST\Builder\ParseQueueProcessor;
-use Doctrine\RST\ErrorManager;
+use Doctrine\RST\Configuration;
 use Doctrine\RST\Kernel;
 use Doctrine\RST\Meta\Metas;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -18,11 +18,11 @@ use function touch;
 
 class ParseQueueProcessorTest extends TestCase
 {
+    /** @var Configuration|MockObject */
+    private $configuration;
+
     /** @var Kernel|MockObject */
     private $kernel;
-
-    /** @var ErrorManager|MockObject */
-    private $errorManager;
 
     /** @var Metas|MockObject */
     private $metas;
@@ -64,8 +64,8 @@ class ParseQueueProcessorTest extends TestCase
 
     protected function setUp(): void
     {
+        $this->configuration   = $this->createMock(Configuration::class);
         $this->kernel          = $this->createMock(Kernel::class);
-        $this->errorManager    = $this->createMock(ErrorManager::class);
         $this->metas           = $this->createMock(Metas::class);
         $this->documents       = $this->createMock(Documents::class);
         $this->directory       = sys_get_temp_dir();
@@ -73,8 +73,8 @@ class ParseQueueProcessorTest extends TestCase
         $this->fileExtension   = 'rst';
 
         $this->parseQueueProcessor = new ParseQueueProcessor(
+            $this->configuration,
             $this->kernel,
-            $this->errorManager,
             $this->metas,
             $this->documents,
             $this->directory,

--- a/tests/BuilderDuplicateAnchors/BuilderDuplicateAnchorsTest.php
+++ b/tests/BuilderDuplicateAnchors/BuilderDuplicateAnchorsTest.php
@@ -4,32 +4,12 @@ declare(strict_types=1);
 
 namespace Doctrine\Tests\RST\BuilderDuplicateAnchors;
 
-use Doctrine\RST\Builder;
-use Doctrine\RST\Configuration;
-use Doctrine\RST\ErrorManager;
-use Doctrine\RST\Kernel;
 use Doctrine\Tests\RST\BaseBuilderTest;
-use PHPUnit\Framework\MockObject\MockObject;
 
 class BuilderDuplicateAnchorsTest extends BaseBuilderTest
 {
-    private Configuration $configuration;
-
-    /** @var ErrorManager|MockObject */
-    private $errorManager;
-
-    protected function setUp(): void
-    {
-        $this->configuration = new Configuration();
-        $this->configuration->setUseCachedMetas(false);
-
-        $this->errorManager = $this->createMock(ErrorManager::class);
-        $this->builder      = new Builder(new Kernel($this->configuration), $this->errorManager);
-    }
-
     public function testDuplicateReferenceSetsWarning(): void
     {
-        $this->errorManager->expects(self::atLeastOnce())->method('warning');
         $this->builder->build($this->sourceFile(), $this->targetFile());
     }
 
@@ -42,6 +22,11 @@ class BuilderDuplicateAnchorsTest extends BaseBuilderTest
         $contents = $this->getFileContents($this->targetFile('index.html'));
 
         self::assertStringContainsString(' id="an-anchor-2"', $contents);
+    }
+
+    protected function configureExpectedWarnings(): void
+    {
+        $this->errorManager->expects(self::atLeastOnce())->method('warning');
     }
 
     protected function getFixturesDirectory(): string

--- a/tests/BuilderDuplicateAnchorsInTwoFiles/BuilderDuplicateAnchorsInTwoFilesTest.php
+++ b/tests/BuilderDuplicateAnchorsInTwoFiles/BuilderDuplicateAnchorsInTwoFilesTest.php
@@ -4,32 +4,12 @@ declare(strict_types=1);
 
 namespace Doctrine\Tests\RST\BuilderDuplicateAnchorsInTwoFiles;
 
-use Doctrine\RST\Builder;
-use Doctrine\RST\Configuration;
-use Doctrine\RST\ErrorManager;
-use Doctrine\RST\Kernel;
 use Doctrine\Tests\RST\BaseBuilderTest;
-use PHPUnit\Framework\MockObject\MockObject;
 
 class BuilderDuplicateAnchorsInTwoFilesTest extends BaseBuilderTest
 {
-    private Configuration $configuration;
-
-    /** @var ErrorManager|MockObject */
-    private $errorManager;
-
-    protected function setUp(): void
-    {
-        $this->configuration = new Configuration();
-        $this->configuration->setUseCachedMetas(false);
-
-        $this->errorManager = $this->createMock(ErrorManager::class);
-        $this->builder      = new Builder(new Kernel($this->configuration), $this->errorManager);
-    }
-
     public function testDuplicateReferenceSetsWarning(): void
     {
-        $this->errorManager->expects(self::atLeastOnce())->method('warning');
         $this->builder->build($this->sourceFile(), $this->targetFile());
     }
 
@@ -44,6 +24,11 @@ class BuilderDuplicateAnchorsInTwoFilesTest extends BaseBuilderTest
         $contents .= $this->getFileContents($this->targetFile('index.html'));
 
         self::assertStringContainsString(' id="an-anchor-2"', $contents);
+    }
+
+    protected function configureExpectedWarnings(): void
+    {
+        $this->errorManager->expects(self::atLeastOnce())->method('warning');
     }
 
     protected function getFixturesDirectory(): string

--- a/tests/BuilderInvalidReferences/BuilderInvalidReferencesTest.php
+++ b/tests/BuilderInvalidReferences/BuilderInvalidReferencesTest.php
@@ -4,37 +4,28 @@ declare(strict_types=1);
 
 namespace Doctrine\Tests\RST\BuilderInvalidReferences;
 
-use Doctrine\RST\Builder;
-use Doctrine\RST\Configuration;
-use Doctrine\RST\Kernel;
 use Doctrine\Tests\RST\BaseBuilderTest;
-use Throwable;
 
 class BuilderInvalidReferencesTest extends BaseBuilderTest
 {
-    /** @var Configuration */
-    private $configuration;
-
-    protected function setUp(): void
-    {
-        $this->configuration = new Configuration();
-        $this->configuration->setUseCachedMetas(false);
-        $this->configuration->silentOnError(true);
-
-        $this->builder = new Builder(new Kernel($this->configuration));
-    }
-
     public function testInvalidReference(): void
     {
-        $this->expectException(Throwable::class);
-        $this->expectExceptionMessage('Found invalid reference "does_not_exist" in file "index"');
-
+        $this->configureExpectedErrors();
         $this->builder->build($this->sourceFile(), $this->targetFile());
+    }
+
+    protected function configureExpectedErrors(): void
+    {
+        $this->errorManager->expects(self::atLeastOnce())
+            ->method('error')
+            ->with('Found invalid reference "does_not_exist"', 'index', null, null);
     }
 
     public function testInvalidReferenceIgnored(): void
     {
         $this->configuration->setIgnoreInvalidReferences(true);
+
+        $this->errorManager->expects(self::never())->method('error');
 
         $this->builder->build($this->sourceFile(), $this->targetFile());
 

--- a/tests/BuilderMalformedReference/BuilderMalformedReferenceTest.php
+++ b/tests/BuilderMalformedReference/BuilderMalformedReferenceTest.php
@@ -4,30 +4,28 @@ declare(strict_types=1);
 
 namespace Doctrine\Tests\RST\BuilderMalformedReference;
 
-use Doctrine\RST\Builder;
-use Doctrine\RST\Configuration;
-use Doctrine\RST\Kernel;
 use Doctrine\Tests\RST\BaseBuilderTest;
 
 class BuilderMalformedReferenceTest extends BaseBuilderTest
 {
-    /** @var Configuration */
-    private $configuration;
-
-    protected function setUp(): void
+    protected function configureExpectedErrors(): void
     {
-        $this->configuration = new Configuration();
-        $this->configuration->setUseCachedMetas(false);
-        $this->configuration->abortOnError(false);
-        $this->configuration->setIgnoreInvalidReferences(true);
-
-        $this->builder = new Builder(new Kernel($this->configuration));
+        $this->errorManager->expects(self::atLeastOnce())
+            ->method('error')
+            ->with('Found invalid reference "_test_reference"', 'subdir/another', null, null);
     }
 
-    public function testMalformedReference(): void
+    public function testMalformedReferenceLogsError(): void
     {
-        // test that invalid references can be ignored and no exception gets thrown
+        $this->configureExpectedErrors();
+        $this->builder->build($this->sourceFile(), $this->targetFile());
+    }
 
+    public function testMalformedReferenceWithIgnoredInvalidReferences(): void
+    {
+        $this->configuration->setIgnoreInvalidReferences(true);
+        // test that invalid references can be ignored and no exception gets thrown
+        $this->errorManager->expects(self::never())->method('error');
         $this->builder->build($this->sourceFile(), $this->targetFile());
 
         $contents = $this->getFileContents($this->targetFile('subdir/another.html'));

--- a/tests/BuilderReferenceDoesNotExist/BuilderReferenceDoesNotExistTest.php
+++ b/tests/BuilderReferenceDoesNotExist/BuilderReferenceDoesNotExistTest.php
@@ -4,25 +4,15 @@ declare(strict_types=1);
 
 namespace Doctrine\Tests\RST\BuilderReferenceDoesNotExist;
 
-use Doctrine\RST\Builder;
-use Doctrine\RST\Configuration;
-use Doctrine\RST\Kernel;
 use Doctrine\Tests\RST\BaseBuilderTest;
 
 class BuilderReferenceDoesNotExistTest extends BaseBuilderTest
 {
-    /** @var Configuration */
-    private $configuration;
-
-    protected function setUp(): void
+    protected function configureExpectedErrors(): void
     {
-        $this->configuration = new Configuration();
-        $this->configuration->setUseCachedMetas(false);
-        $this->configuration->abortOnError(false);
-        $this->configuration->silentOnError(true);
-        $this->configuration->setIgnoreInvalidReferences(false);
-
-        $this->builder = new Builder(new Kernel($this->configuration));
+        $this->errorManager->expects(self::atLeastOnce())
+            ->method('error')
+            ->with('Found invalid reference "does-not-exist"', 'subdir/index', null, null);
     }
 
     public function testReferenceDoesNotExist(): void

--- a/tests/BuilderReferences/BuilderReferencesTest.php
+++ b/tests/BuilderReferences/BuilderReferencesTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Doctrine\Tests\RST\BuilderReferences;
 
-use Doctrine\RST\Builder;
 use Doctrine\Tests\RST\BaseBuilderTest;
 use Gajus\Dindent\Indenter;
 use Symfony\Component\Finder\Finder;
@@ -13,10 +12,11 @@ use function rtrim;
 
 class BuilderReferencesTest extends BaseBuilderTest
 {
-    protected function configureBuilder(Builder $builder): void
+    protected function configureExpectedErrors(): void
     {
-        $builder->getConfiguration()->abortOnError(false);
-        $builder->getConfiguration()->silentOnError();
+        $this->errorManager->expects(self::atLeastOnce())
+            ->method('error')
+            ->with('Found invalid reference "Some Sub Section"', 'index', null, null);
     }
 
     public function test(): void

--- a/tests/BuilderUrl/BuilderUrlTest.php
+++ b/tests/BuilderUrl/BuilderUrlTest.php
@@ -4,18 +4,12 @@ declare(strict_types=1);
 
 namespace Doctrine\Tests\RST\BuilderUrl;
 
-use Doctrine\RST\Builder;
-use Doctrine\RST\Configuration;
-use Doctrine\RST\Kernel;
 use Doctrine\Tests\RST\BaseBuilderTest;
 
 use function strpos;
 
 class BuilderUrlTest extends BaseBuilderTest
 {
-    /** @var Configuration */
-    private $configuration;
-
     public function testBaseUrl(): void
     {
         $this->configuration->setBaseUrl('https://www.domain.com/directory');
@@ -137,9 +131,8 @@ class BuilderUrlTest extends BaseBuilderTest
 
     protected function setUp(): void
     {
-        $this->configuration = new Configuration();
+        parent::setUp();
         $this->configuration->setUseCachedMetas(false);
-        $this->builder = new Builder(new Kernel($this->configuration));
     }
 
     protected function getFixturesDirectory(): string

--- a/tests/BuilderWithErrors/BuilderWithErrorsTest.php
+++ b/tests/BuilderWithErrors/BuilderWithErrorsTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Doctrine\Tests\RST\BuilderWithErrors;
 
-use Doctrine\RST\Builder;
 use Doctrine\Tests\RST\BaseBuilderTest;
 use Symfony\Component\DomCrawler\Crawler;
 
@@ -12,29 +11,24 @@ use function trim;
 
 class BuilderWithErrorsTest extends BaseBuilderTest
 {
-    protected function configureBuilder(Builder $builder): void
-    {
-        $builder->getConfiguration()->abortOnError(false);
-        $builder->getConfiguration()->silentOnError(true);
-    }
-
     public function testNoContentDirectiveError(): void
     {
         $contents = $this->getFileContents($this->targetFile('no_content_directive.html'));
         $crawler  = new Crawler($contents);
         $bodyHtml = trim($crawler->filter('body')->html());
-
         // the note is simply left out
         self::assertSame(<<<'EOF'
 <p>Testing wrapper node at end of file</p>
 <p>And here is more text.</p>
 EOF
             , $bodyHtml);
+    }
 
-        self::assertEquals(
-            'Error while processing "note" directive: "Content expected, none found." in file "no_content_directive" at line 6',
-            $this->builder->getErrorManager()->getErrors()[0]->asString()
-        );
+    protected function configureExpectedErrors(): void
+    {
+        $this->errorManager->expects(self::atLeastOnce())
+            ->method('error')
+            ->with('Error while processing "note" directive: "Content expected, none found."');
     }
 
     protected function getFixturesDirectory(): string

--- a/tests/ErrorManagerTest.php
+++ b/tests/ErrorManagerTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\Tests\RST;
 
 use Doctrine\RST\Configuration;
-use Doctrine\RST\ErrorManager;
+use Doctrine\RST\ErrorManager\DefaultErrorManager;
 use PHPUnit\Framework\TestCase;
 
 class ErrorManagerTest extends TestCase
@@ -20,7 +20,7 @@ class ErrorManagerTest extends TestCase
             ->method('isSilentOnError')
             ->willReturn(true);
 
-        $errorManager = new ErrorManager($configuration);
+        $errorManager = new DefaultErrorManager($configuration);
         $errorManager->error('ERROR FOO');
         $errorManager->error('ERROR BAR');
 

--- a/tests/Functional/FunctionalTest.php
+++ b/tests/Functional/FunctionalTest.php
@@ -57,7 +57,7 @@ class FunctionalTest extends TestCase
         $configuration->setFileExtension(Format::HTML);
         $configuration->setUseCachedMetas(false);
         $kernel  = new Kernel($configuration);
-        $builder = new Builder($kernel);
+        $builder = new Builder($configuration, $kernel);
 
         $builder->build(__DIR__ . '/tests/build/' . $file, __DIR__ . '/output/build/' . $file);
 
@@ -224,7 +224,7 @@ class FunctionalTest extends TestCase
         $configuration->silentOnError(true);
 
         $kernel = new Kernel($configuration);
-        $parser =  new Parser($kernel);
+        $parser =  new Parser($configuration, $kernel);
 
         $environment = $parser->getEnvironment();
         $environment->setCurrentDirectory($currentDirectory);

--- a/tests/HTML/IndentHTMLTest.php
+++ b/tests/HTML/IndentHTMLTest.php
@@ -18,7 +18,7 @@ class IndentHTMLTest extends TestCase
 
         $kernel = new Kernel($configuration);
 
-        $parser = new Parser($kernel);
+        $parser = new Parser($configuration, $kernel);
 
         $document = $parser->parse('Test paragraph.');
 

--- a/tests/LinkParserTest.php
+++ b/tests/LinkParserTest.php
@@ -79,6 +79,6 @@ EOF;
     {
         $this->configuration = new Configuration();
 
-        $this->parser = new Parser(new Kernel($this->configuration));
+        $this->parser = new Parser($this->configuration, new Kernel($this->configuration));
     }
 }

--- a/tests/LiteralNestedInDirective/BuilderTest.php
+++ b/tests/LiteralNestedInDirective/BuilderTest.php
@@ -19,13 +19,14 @@ class BuilderTest extends BaseBuilderTest
     protected function setUp(): void
     {
         shell_exec('rm -rf ' . $this->targetFile());
+        $configuration = new Configuration();
 
         $kernel = new Kernel(
-            new Configuration(),
+            $configuration,
             [new TipDirective()]
         );
 
-        $this->builder = new Builder($kernel);
+        $this->builder = new Builder($configuration, $kernel);
         $this->builder->getConfiguration()->setUseCachedMetas(false);
 
         $this->builder->build($this->sourceFile(), $this->targetFile());

--- a/tests/Meta/CachedMetasLoaderTest.php
+++ b/tests/Meta/CachedMetasLoaderTest.php
@@ -4,24 +4,20 @@ declare(strict_types=1);
 
 namespace Doctrine\Tests\RST\Meta;
 
-use Doctrine\RST\ErrorManager;
 use Doctrine\RST\Meta\CachedMetasLoader;
 use Doctrine\RST\Meta\LinkTarget;
 use Doctrine\RST\Meta\MetaEntry;
 use Doctrine\RST\Meta\Metas;
-use PHPUnit\Framework\MockObject\MockObject;
-use PHPUnit\Framework\TestCase;
+use Doctrine\Tests\RST\BaseTest;
 
 use function sys_get_temp_dir;
 
-class CachedMetasLoaderTest extends TestCase
+class CachedMetasLoaderTest extends BaseTest
 {
-    /** @var ErrorManager|MockObject */
-    private ErrorManager $errorManager;
-
     protected function setUp(): void
     {
-        $this->errorManager = $this->createMock(ErrorManager::class);
+        parent::setUp();
+        $this->configuration->setUseCachedMetas(false);
     }
 
     public function testSaveAndLoadCachedMetaEntries(): void
@@ -30,8 +26,8 @@ class CachedMetasLoaderTest extends TestCase
         $meta1     = new MetaEntry('file1', 'url1', 'title1', [], [], [], [], 0);
         $meta2     = new MetaEntry('file2', 'url2', 'title2', [], [], [], [], 0);
 
-        $metasBefore = new Metas($this->errorManager, [$meta1, $meta2]);
-        $metasAfter  = new Metas($this->errorManager);
+        $metasBefore = new Metas($this->configuration, [$meta1, $meta2]);
+        $metasAfter  = new Metas($this->configuration);
 
         $loader = new CachedMetasLoader();
         $loader->cacheMetaEntries($targetDir, $metasBefore);
@@ -45,8 +41,8 @@ class CachedMetasLoaderTest extends TestCase
         $linkEntry1 = new LinkTarget('name1', 'url1', 'Some Title');
         $linkEntry2 = new LinkTarget('name2', 'url2');
 
-        $metasBefore = new Metas($this->errorManager, [], ['name1' => $linkEntry1, 'name2' => $linkEntry2]);
-        $metasAfter  = new Metas($this->errorManager);
+        $metasBefore = new Metas($this->configuration, [], ['name1' => $linkEntry1, 'name2' => $linkEntry2]);
+        $metasAfter  = new Metas($this->configuration);
 
         $loader = new CachedMetasLoader();
         $loader->cacheMetaEntries($targetDir, $metasBefore);

--- a/tests/MetasTest.php
+++ b/tests/MetasTest.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace Doctrine\Tests\RST;
 
+use Doctrine\RST\Configuration;
 use Doctrine\RST\ErrorManager;
+use Doctrine\RST\ErrorManager\ErrorManagerFactory;
 use Doctrine\RST\Meta\LinkTarget;
 use Doctrine\RST\Meta\MetaEntry;
 use Doctrine\RST\Meta\Metas;
@@ -13,12 +15,20 @@ use PHPUnit\Framework\TestCase;
 
 class MetasTest extends TestCase
 {
+    private Configuration $configuration;
     /** @var ErrorManager|MockObject */
     private ErrorManager $errorManager;
 
     protected function setUp(): void
     {
-        $this->errorManager = $this->createMock(ErrorManager::class);
+        $this->configuration = new Configuration();
+        $this->configuration->setUseCachedMetas(false);
+        $this->errorManager  = $this->createMock(ErrorManager::class);
+        $errorManagerFactory = $this->createMock(ErrorManagerFactory::class);
+        $this->configuration->setErrorManagerFactory($errorManagerFactory);
+        $errorManagerFactory->method('getErrorManager')->willReturn($this->errorManager);
+        $this->errorManager->expects(self::never())->method('warning');
+        $this->errorManager->expects(self::never())->method('error');
     }
 
     public function testFindLinkMetaEntry(): void
@@ -52,7 +62,7 @@ class MetasTest extends TestCase
         );
 
         $metas = new Metas(
-            $this->errorManager,
+            $this->configuration,
             [
                 $entry1,
                 $entry2,

--- a/tests/Parser/DocumentParserTest.php
+++ b/tests/Parser/DocumentParserTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\Tests\RST\Parser;
 
 use Doctrine\Common\EventManager;
+use Doctrine\RST\Configuration;
 use Doctrine\RST\Directives\Directive;
 use Doctrine\RST\Environment;
 use Doctrine\RST\ErrorManager;
@@ -20,12 +21,14 @@ class DocumentParserTest extends TestCase
     {
         $parser             = $this->createMock(Parser::class);
         $environment        = $this->createMock(Environment::class);
+        $configuration      = $this->createMock(Configuration::class);
         $nodeFactory        = $this->createMock(NodeFactory::class);
         $eventManager       = $this->createMock(EventManager::class);
         $codeBlockDirective = $this->createMock(Directive::class);
         $errorManager       = $this->createMock(ErrorManager::class);
 
         $docParser = new DocumentParser(
+            $configuration,
             $parser,
             $environment,
             $nodeFactory,
@@ -42,7 +45,11 @@ class DocumentParserTest extends TestCase
             ->method('getName')
             ->willReturn('code-block-name');
 
-        $environment->expects(self::once())
+        $environment
+            ->method('getConfiguration')
+            ->willReturn($configuration);
+
+        $configuration->expects(self::once())
             ->method('getErrorManager')
             ->willReturn($errorManager);
 

--- a/tests/Parser/ParserTest.php
+++ b/tests/Parser/ParserTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\Tests\RST\Parser;
 
+use Doctrine\RST\Configuration;
 use Doctrine\RST\Nodes\CodeNode;
 use Doctrine\RST\Nodes\DocumentNode;
 use Doctrine\RST\Nodes\DummyNode;
@@ -30,6 +31,7 @@ use function trim;
  */
 class ParserTest extends TestCase
 {
+    private Configuration $configuration;
     /** @var Parser $parser */
     protected $parser;
 
@@ -37,8 +39,9 @@ class ParserTest extends TestCase
     {
         parent::setUp();
 
-        $directory = __DIR__ . '/files/';
-        $parser    = new Parser();
+        $this->configuration = new Configuration();
+        $directory           = __DIR__ . '/files/';
+        $parser              = new Parser($this->configuration);
 
         $parser->getEnvironment()->setCurrentDirectory($directory);
 
@@ -47,7 +50,7 @@ class ParserTest extends TestCase
 
     public function testGetSubParserPassesConfiguration(): void
     {
-        $parser = new Parser();
+        $parser = new Parser($this->configuration);
 
         $configuration = $parser->getEnvironment()->getConfiguration();
 
@@ -278,7 +281,7 @@ class ParserTest extends TestCase
 
     public function testThrowExceptionOnInvalidFileInclude(): void
     {
-        $parser      = new Parser();
+        $parser      = new Parser($this->configuration);
         $environment = $parser->getEnvironment();
 
         $data = file_get_contents(__DIR__ . '/files/inclusion-bad.rst');
@@ -319,7 +322,7 @@ class ParserTest extends TestCase
     {
         $directory = __DIR__ . '/files';
 
-        $parser = new Parser();
+        $parser = new Parser($this->configuration);
         $parser->getEnvironment()->setCurrentDirectory($directory);
 
         /** @var TitleNode[] $nodes1 */
@@ -384,7 +387,7 @@ class ParserTest extends TestCase
     public function testIncludesPolicy(): void
     {
         $directory   = __DIR__ . '/files/';
-        $parser      = new Parser();
+        $parser      = new Parser($this->configuration);
         $environment = $parser->getEnvironment();
         $environment->setCurrentDirectory($directory);
 
@@ -418,7 +421,7 @@ class ParserTest extends TestCase
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('File at path does-not-exist.rst does not exist');
 
-        $parser = new Parser();
+        $parser = new Parser($this->configuration);
         $parser->parseFile('does-not-exist.rst');
     }
 

--- a/tests/RefInsideDirective/BuilderTest.php
+++ b/tests/RefInsideDirective/BuilderTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\Tests\RST\RefInsideDirective;
 
 use Doctrine\RST\Builder;
+use Doctrine\RST\Configuration;
 use Doctrine\RST\Kernel;
 use PHPUnit\Framework\TestCase;
 
@@ -15,8 +16,9 @@ class BuilderTest extends TestCase
 {
     public function testRefInsideDirective(): void
     {
-        $kernel  = new Kernel(null, [new VersionAddedDirective()]);
-        $builder = new Builder($kernel);
+        $configuration = new Configuration();
+        $kernel        = new Kernel($configuration, [new VersionAddedDirective()]);
+        $builder       = new Builder($configuration, $kernel);
         $builder->getConfiguration()->setUseCachedMetas(false);
 
         $builder->build(

--- a/tests/TextRoles/EnvironmentTest.php
+++ b/tests/TextRoles/EnvironmentTest.php
@@ -7,6 +7,7 @@ namespace Doctrine\Tests\RST\TextRoles;
 use Doctrine\RST\Configuration;
 use Doctrine\RST\Environment;
 use Doctrine\RST\ErrorManager;
+use Doctrine\RST\ErrorManager\ErrorManagerFactory;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
@@ -18,9 +19,12 @@ class EnvironmentTest extends TestCase
 
     protected function setUp(): void
     {
-        $configuration      = new Configuration();
-        $this->errorManager = $this->createMock(ErrorManager::class);
-        $this->environment  = new Environment($configuration, null, $this->errorManager);
+        $configuration       = new Configuration();
+        $errorManagerFactory = $this->createMock(ErrorManagerFactory::class);
+        $this->errorManager  = $this->createMock(ErrorManager::class);
+        $configuration->setErrorManagerFactory($errorManagerFactory);
+        $errorManagerFactory->method('getErrorManager')->willReturn($this->errorManager);
+        $this->environment = new Environment($configuration);
     }
 
     public function testRegisterTextRole(): void


### PR DESCRIPTION
* ErrorHandler is an interface now
* ErrorHandler is created by Factory
* The DefaultErrorHandler should exist only once per Configuration
* Configuration is responsible for delivering the ErrorHandler
* You can get your ErrorHandler only from the configuration, no other class should expose it so we have a single point of truth
* You can register your own ErrorHandler by using another ErrorHandlerFactory
* You can mock the ErrorHandlerFactory to test for expected / non-expected warnigns and errors
* Adjust Builder Tests to never expect warnings and errors unless configured to expect errors.