### PR TITLE
[FEATURE] Allow multiple whitespaces as separator in directives and links

### DIFF
--- a/lib/Parser/LineChecker.php
+++ b/lib/Parser/LineChecker.php
@@ -114,12 +114,12 @@ class LineChecker
 
     public function isComment(string $line): bool
     {
-        return preg_match('/^\.\.(?: [^_]((?:(?!::).)*))?$/mUsi', $line) > 0;
+        return preg_match('/^\.\.(?:\s+[^_ \t]((?:(?!::).)*))?$/mUsi', $line) > 0;
     }
 
     public function isDirective(string $line): bool
     {
-        return preg_match('/^\.\. (\|(.+)\| |)([^\s]+)::( (.*)|)$/mUsi', $line) > 0;
+        return preg_match('/^\.\.\s+(\|(.+)\| |)([^\s]+)::( (.*)|)$/mUsi', $line) > 0;
     }
 
     public function isFieldOption(string $line, int $offset = 0): bool

--- a/lib/Parser/LineDataParser.php
+++ b/lib/Parser/LineDataParser.php
@@ -38,30 +38,30 @@ final class LineDataParser
     public function parseLinkTarget(string $line): ?Link
     {
         // Links
-        if (preg_match('/^\.\. _`(.+)`: (.+)$/mUsi', $line, $match) > 0) {
+        if (preg_match('/^\.\.\s+_`(.+)`: (.+)$/mUsi', $line, $match) > 0) {
             return $this->createLinkTarget($match[1], $match[2], Link::TYPE_LINK);
         }
 
         // anonymous links
-        if (preg_match('/^\.\. _(.+): (.+)$/mUsi', $line, $match) > 0) {
+        if (preg_match('/^\.\.\s+_(.+): (.+)$/mUsi', $line, $match) > 0) {
             return $this->createLinkTarget($match[1], $match[2], Link::TYPE_LINK);
         }
 
         // Short anonymous links
-        if (preg_match('/^__ (.+)$/mUsi', trim($line), $match) > 0) {
+        if (preg_match('/^__\s+(.+)$/mUsi', trim($line), $match) > 0) {
             $url = $match[1];
 
-            return $this->createLinkTarget('_', $url, Link::TYPE_LINK);
+            return $this->createLinkTarget('_', trim($url), Link::TYPE_LINK);
         }
 
         // Anchor links - ".. _`anchor-link`:"
-        if (preg_match('/^\.\. _`(.+)`:$/mUsi', trim($line), $match) > 0) {
+        if (preg_match('/^\.\.\s+_`(.+)`:$/mUsi', trim($line), $match) > 0) {
             $anchor = $match[1];
 
             return new Link($anchor, '#' . $anchor, Link::TYPE_ANCHOR);
         }
 
-        if (preg_match('/^\.\. _(.+):$/mUsi', trim($line), $match) > 0) {
+        if (preg_match('/^\.\.\s+_(.+):$/mUsi', trim($line), $match) > 0) {
             $anchor = $match[1];
 
             return $this->createLinkTarget($anchor, '#' . $anchor, Link::TYPE_ANCHOR);
@@ -82,7 +82,7 @@ final class LineDataParser
 
     public function parseDirective(string $line): ?Directive
     {
-        if (preg_match('/^\.\. (\|(.+)\| |)([^\s]+)::( (.*)|)$/mUsi', $line, $match) > 0) {
+        if (preg_match('/^\.\.\s+(\|(.+)\| |)([^\s]+)::( (.*)|)$/mUsi', $line, $match) > 0) {
             return new Directive(
                 $match[2],
                 $match[3],

--- a/tests/Functional/tests/render/anchor-whitespace/anchor-whitespace.html
+++ b/tests/Functional/tests/render/anchor-whitespace/anchor-whitespace.html
@@ -1,0 +1,8 @@
+<div class="section" id="anchors">
+    <h1>
+        Anchors
+    </h1>
+    <a id="lists"></a>
+
+    <p><a href="#lists">go to lists</a></p>
+</div>

--- a/tests/Functional/tests/render/anchor-whitespace/anchor-whitespace.rst
+++ b/tests/Functional/tests/render/anchor-whitespace/anchor-whitespace.rst
@@ -1,0 +1,6 @@
+Anchors
+-------
+
+..  _lists:
+
+`go to lists <#lists>`_

--- a/tests/Functional/tests/render/directive-whitespace/directive-whitespace.html
+++ b/tests/Functional/tests/render/directive-whitespace/directive-whitespace.html
@@ -1,0 +1,30 @@
+<div class="alert tip-admonition bg-success text-light border ">
+    <table width="100%">
+        <tr>
+            <td width="10" class="align-top" title="Tip"><i class="fas fa-question-circle mr-2"></i></td>
+            <td>
+                <p>Directive with one space</p>
+            </td>
+        </tr>
+    </table>
+</div>
+<div class="alert tip-admonition bg-success text-light border ">
+<table width="100%">
+    <tr>
+        <td width="10" class="align-top" title="Tip"><i class="fas fa-question-circle mr-2"></i></td>
+        <td>
+            <p>Directive with two spaces</p>
+        </td>
+    </tr>
+</table>
+</div>
+<div class="alert tip-admonition bg-success text-light border ">
+    <table width="100%">
+        <tr>
+            <td width="10" class="align-top" title="Tip"><i class="fas fa-question-circle mr-2"></i></td>
+            <td>
+                <p>Directive with indentation of 3 spaces</p>
+            </td>
+        </tr>
+    </table>
+</div>

--- a/tests/Functional/tests/render/directive-whitespace/directive-whitespace.rst
+++ b/tests/Functional/tests/render/directive-whitespace/directive-whitespace.rst
@@ -1,0 +1,8 @@
+.. tip::
+    Directive with one space
+
+..  tip::
+    Directive with two spaces
+
+.. tip::
+   Directive with indentation of 3 spaces

--- a/tests/Functional/tests/render/links-whitespaces/links-whitespaces.html
+++ b/tests/Functional/tests/render/links-whitespaces/links-whitespaces.html
@@ -1,0 +1,5 @@
+<p>This is a link to <a href="http://xkcd.com/">xkcd</a> spacy</p>
+<p>This is another link to <a href="http://something.com/">something</a></p>
+<p>This is an <a href="http://anonymous.com/">anonymous link</a></p>
+<p>I love <a href="http://www.github.com/">GitHub</a></p>
+<p>You can read more on the features of Embeddables objects <a href="http://docs.doctrine-project.org/en/latest/tutorials/embeddables.html">in the documentation</a>.</p>

--- a/tests/Functional/tests/render/links-whitespaces/links-whitespaces.rst
+++ b/tests/Functional/tests/render/links-whitespaces/links-whitespaces.rst
@@ -1,0 +1,17 @@
+This is a link to `xkcd`_ spacy
+
+This is another link to something_
+
+This is an `anonymous link`__
+
+__  http://anonymous.com/
+
+I love GitHub__
+
+..  __: http://www.github.com/
+
+You can read more on the features of Embeddables objects `in the documentation
+<http://docs.doctrine-project.org/en/latest/tutorials/embeddables.html>`_.
+
+..  _`xkcd`: http://xkcd.com/
+..  _something: http://something.com/

--- a/tests/Functional/tests/render/list-whitespace/list-whitespace.html
+++ b/tests/Functional/tests/render/list-whitespace/list-whitespace.html
@@ -1,0 +1,12 @@
+<div class="section" id="list-with-indentation-of-4-spaces-3-after-sign">
+    <h1>
+        List with indentation of 4 spaces / 3 after sign
+    </h1>
+    <ul>
+        <li>This is</li>
+        <li>A simple</li>
+        <li>Unordered
+            With 4 spaces in an other line</li>
+        <li>List with an indentation of 4</li>
+    </ul>
+</div>

--- a/tests/Functional/tests/render/list-whitespace/list-whitespace.rst
+++ b/tests/Functional/tests/render/list-whitespace/list-whitespace.rst
@@ -1,0 +1,9 @@
+
+List with indentation of 4 spaces / 3 after sign
+================================================
+
+*   This is
+*   A simple
+*   Unordered
+    With 4 spaces in an other line
+*   List with an indentation of 4


### PR DESCRIPTION
In the TYPO3 docs we like to use 2 white spaces after the two dots `..  ` marking the start of a directive or link. This is achieved in the editors by pressing tab after the two dots. This way directive and their blocks are aligned when using 4 spaces for indentation:

```
..  my-directive:: something
    My directives content
```

Currently such a directive or link is not detected to be a directive. However RST Syntax allows this: https://docutils.sourceforge.io/0.4/docs/ref/rst/restructuredtext.html#whitespace

For the time being tabs are not possible as blocks indented with tabs are not recognized. Tabs are allowed but not recommended by the rst syntax. Shall we disallow tabs and maybe issue a warning when a file contains tabs?