### PR TITLE
[BUGFIX] Followup: Fix tests after merging

### DIFF
--- a/tests/BuilderUnknownDirective/BuilderUnknownDirectiveTest.php
+++ b/tests/BuilderUnknownDirective/BuilderUnknownDirectiveTest.php
@@ -4,24 +4,14 @@ declare(strict_types=1);
 
 namespace Doctrine\Tests\RST\BuilderUnknownDirective;
 
-use Doctrine\RST\Builder;
-use Doctrine\RST\Configuration;
-use Doctrine\RST\Kernel;
 use Doctrine\Tests\RST\BaseBuilderTest;
 
 class BuilderUnknownDirectiveTest extends BaseBuilderTest
 {
-    /** @var Configuration */
-    private $configuration;
-
     protected function setUp(): void
     {
-        $this->configuration = new Configuration();
-        $this->configuration->setUseCachedMetas(false);
-        $this->configuration->silentOnError(true);
+        parent::setUp();
         $this->configuration->abortOnError(false);
-
-        $this->builder = new Builder(new Kernel($this->configuration));
     }
 
     public function testUnknownDirectiveWithFieldOptions(): void
@@ -29,6 +19,13 @@ class BuilderUnknownDirectiveTest extends BaseBuilderTest
         $this->builder->build($this->sourceFile(), $this->targetFile());
         $contents = $this->getFileContents($this->targetFile('index.html'));
         self::assertStringNotContainsString('<p>Test link 2 to</p>', $contents);
+    }
+
+    protected function configureExpectedErrors(): void
+    {
+        $this->errorManager->expects(self::atLeastOnce())
+            ->method('error')
+            ->with('Unknown directive "unknown-directive" for line ".. unknown-directive:: some content"');
     }
 
     protected function getFixturesDirectory(): string


### PR DESCRIPTION
It seems like something was overlooked on merging. In the current 0.6 branch unit and phpstan test are red. This PR fixes the tests.

@greg0ire, @SenseException  let us merge this fast, as all tests are red right now and no further devlopment is possible