### PR TITLE
[TASK] Delegate escaping to Twig where possible

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
         "symfony/polyfill-mbstring": "^1.0",
         "symfony/string": "^5.3 || ^6.0",
         "symfony/translation-contracts": "^1.1 || ^2.0",
-        "twig/twig": "^2.15.3 || ^3.4.3"
+        "twig/twig": "^3.5.0"
     },
     "require-dev": {
         "doctrine/coding-standard": "^10.0",

--- a/lib/Span/SpanProcessor.php
+++ b/lib/Span/SpanProcessor.php
@@ -7,7 +7,6 @@ namespace Doctrine\RST\Span;
 use Doctrine\RST\Environment;
 use Doctrine\RST\Meta\LinkTarget;
 
-use function htmlspecialchars;
 use function mt_rand;
 use function preg_match;
 use function preg_match_all;
@@ -94,7 +93,7 @@ final class SpanProcessor
 
                 $this->addToken(SpanToken::TYPE_LITERAL, $id, [
                     'type' => 'literal',
-                    'text' => htmlspecialchars($match[1]),
+                    'text' => $match[1],
                 ]);
 
                 return $id;
@@ -112,7 +111,7 @@ final class SpanProcessor
 
                 $this->addToken(SpanToken::TYPE_INTERPRETED, $id, [
                     'type' => SpanToken::TYPE_INTERPRETED,
-                    'text' => htmlspecialchars($match[1]),
+                    'text' => $match[1],
                 ]);
 
                 return $id;

--- a/lib/Templates/default/html/interpreted-text.html.twig
+++ b/lib/Templates/default/html/interpreted-text.html.twig
@@ -1,1 +1,1 @@
-<code>{{ text|raw }}</code>
+<code>{{ text }}</code>

--- a/lib/Templates/default/html/literal.html.twig
+++ b/lib/Templates/default/html/literal.html.twig
@@ -1,1 +1,1 @@
-<code>{{ text|raw }}</code>
+<code>{{ text }}</code>

--- a/lib/TextRoles/WrapperTextRole.php
+++ b/lib/TextRoles/WrapperTextRole.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\RST\TextRoles;
 
+use function htmlspecialchars;
 use function sprintf;
 
 class WrapperTextRole extends TextRole
@@ -29,6 +30,6 @@ class WrapperTextRole extends TextRole
 
     public function process(string $text): string
     {
-        return sprintf($this->wrap, $text);
+        return sprintf($this->wrap, htmlspecialchars($text));
     }
 }

--- a/tests/Functional/tests/render/code-block-no-xss/code-block-no-xss.html
+++ b/tests/Functional/tests/render/code-block-no-xss/code-block-no-xss.html
@@ -1,0 +1,6 @@
+<pre><code class="text">&lt;script&gt;alert(&#039;hello!&#039;)&lt;/script&gt;
+</code></pre>
+<pre><code class="html">&lt;script&gt;alert(&#039;hello!&#039;)&lt;/script&gt;
+</code></pre>
+<pre><code class="php">&lt;script&gt;alert(&#039;hello!&#039;)&lt;/script&gt;
+</code></pre>

--- a/tests/Functional/tests/render/code-block-no-xss/code-block-no-xss.rst
+++ b/tests/Functional/tests/render/code-block-no-xss/code-block-no-xss.rst
@@ -1,0 +1,11 @@
+.. code-block:: text
+
+    <script>alert('hello!')</script>
+
+.. code-block:: html
+
+    <script>alert('hello!')</script>
+
+.. code-block:: php
+
+    <script>alert('hello!')</script>

--- a/tests/Functional/tests/render/code-role/code-role.html
+++ b/tests/Functional/tests/render/code-role/code-role.html
@@ -1,1 +1,1 @@
-<p>Some inline <code>code</code>: <code>$this->execute(){}</code>.</p>
+<p>Some inline <code>code</code>: <code>$this-&gt;execute(){}</code>.</p>

--- a/tests/Functional/tests/render/code-textrole-no-xss/code-textrole-no-xss.html
+++ b/tests/Functional/tests/render/code-textrole-no-xss/code-textrole-no-xss.html
@@ -1,0 +1,3 @@
+<p><code>&lt;script&gt;alert(&#039;hello!&#039;)&lt;/script&gt;</code></p>
+<p><code>&lt;script&gt;alert(&#039;hello!&#039;)&lt;/script&gt;</code></p>
+<p><code>$this-&gt;execute(){}</code></p>

--- a/tests/Functional/tests/render/code-textrole-no-xss/code-textrole-no-xss.rst
+++ b/tests/Functional/tests/render/code-textrole-no-xss/code-textrole-no-xss.rst
@@ -1,0 +1,5 @@
+``<script>alert('hello!')</script>``
+
+`<script>alert('hello!')</script>`
+
+:code:`$this->execute(){}`

--- a/tests/Functional/tests/render/text-roles/text-roles.html
+++ b/tests/Functional/tests/render/text-roles/text-roles.html
@@ -6,7 +6,7 @@
 <p><strong class="command">rm</strong></p>
 <p><em class="dfn">something</em></p>
 <p><span class="pre file">/etc/passwd</span></p>
-<p><span class="guilabel">&Cancel</span></p>
+<p><span class="guilabel">&amp;Cancel</span></p>
 <p>Press <kbd class="kbd docutils literal notranslate">ctrl</kbd> + <kbd class="kbd docutils literal notranslate">s</kbd></p>
 <p><em class="mailheader">Content-Type</em></p>
 <p>


### PR DESCRIPTION
After this discussion in the Symfony documentation channel: https://symfony-devs.slack.com/archives/C3ASP9LJJ/p1673725412479199

Added tests that XSS is not possible. Escaping of output should be done as late as possible, usually in the twig template. This way it is always done in the same place and not forgotten. When no twig is used we have to do the escaping right before the HTML is combined. 