### PR TITLE
[FEATURE] Introduce field lists

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,5 +1,9 @@
 # Upgrade to 0.6
 
+## Added methods to NodeFactory
+
+* Added `NodeFactory::createFieldListNode()`.
+
 ## Removed the class Kernel
 
 * Directives and TextRoles can now be registered by adding a DirectiveFactory to

--- a/lib/Configuration.php
+++ b/lib/Configuration.php
@@ -362,6 +362,7 @@ class Configuration
             $this->createNodeInstantiator($environment, NodeTypes::ANCHOR, Nodes\AnchorNode::class),
             $this->createNodeInstantiator($environment, NodeTypes::LIST, Nodes\ListNode::class),
             $this->createNodeInstantiator($environment, NodeTypes::TABLE, Nodes\TableNode::class),
+            $this->createNodeInstantiator($environment, NodeTypes::FIELD_LIST, Nodes\FieldListNode::class),
             $this->createNodeInstantiator($environment, NodeTypes::DEFINITION_LIST, Nodes\DefinitionListNode::class),
             $this->createNodeInstantiator($environment, NodeTypes::WRAPPER, Nodes\WrapperNode::class),
             $this->createNodeInstantiator($environment, NodeTypes::FIGURE, Nodes\FigureNode::class),

--- a/lib/HTML/HTMLFormat.php
+++ b/lib/HTML/HTMLFormat.php
@@ -70,6 +70,14 @@ final class HTMLFormat implements Format
                     );
                 }
             ),
+            Nodes\FieldListNode::class => new CallableNodeRendererFactory(
+                function (Nodes\FieldListNode $node): HTML\Renderers\FieldListNodeRenderer {
+                    return new HTML\Renderers\FieldListNodeRenderer(
+                        $node,
+                        $this->templateRenderer
+                    );
+                }
+            ),
             Nodes\FigureNode::class => new CallableNodeRendererFactory(
                 function (Nodes\FigureNode $node): HTML\Renderers\FigureNodeRenderer {
                     return new HTML\Renderers\FigureNodeRenderer(

--- a/lib/HTML/Renderers/FieldListNodeRenderer.php
+++ b/lib/HTML/Renderers/FieldListNodeRenderer.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\RST\HTML\Renderers;
+
+use Doctrine\RST\Nodes\FieldListNode;
+use Doctrine\RST\Renderers\NodeRenderer;
+use Doctrine\RST\Templates\TemplateRenderer;
+
+final class FieldListNodeRenderer implements NodeRenderer
+{
+    private FieldListNode $listNode;
+
+    private TemplateRenderer $templateRenderer;
+
+    public function __construct(FieldListNode $listNode, TemplateRenderer $templateRenderer)
+    {
+        $this->listNode         = $listNode;
+        $this->templateRenderer = $templateRenderer;
+    }
+
+    public function render(): string
+    {
+        $template = 'field-list.html.twig';
+
+        return $this->templateRenderer->render($template, ['listNode' => $this->listNode]);
+    }
+}

--- a/lib/NodeFactory/DefaultNodeFactory.php
+++ b/lib/NodeFactory/DefaultNodeFactory.php
@@ -15,6 +15,7 @@ use Doctrine\RST\Nodes\ContentsNode;
 use Doctrine\RST\Nodes\DefinitionListNode;
 use Doctrine\RST\Nodes\DocumentNode;
 use Doctrine\RST\Nodes\DummyNode;
+use Doctrine\RST\Nodes\FieldListNode;
 use Doctrine\RST\Nodes\FigureNode;
 use Doctrine\RST\Nodes\ImageNode;
 use Doctrine\RST\Nodes\ListNode;
@@ -35,6 +36,7 @@ use Doctrine\RST\Nodes\TocNode;
 use Doctrine\RST\Nodes\WrapperNode;
 use Doctrine\RST\Parser;
 use Doctrine\RST\Parser\DefinitionList;
+use Doctrine\RST\Parser\FieldOption;
 use Doctrine\RST\Parser\LineChecker;
 use Doctrine\RST\Parser\ListItem;
 use InvalidArgumentException;
@@ -169,6 +171,15 @@ final class DefaultNodeFactory implements NodeFactory
         assert($definitionListNode instanceof DefinitionListNode);
 
         return $definitionListNode;
+    }
+
+    /** @param FieldOption[] $items */
+    public function createFieldListNode(array $items): FieldListNode
+    {
+        $fieldListNode = $this->create(NodeTypes::FIELD_LIST, [$items]);
+        assert($fieldListNode instanceof FieldListNode);
+
+        return $fieldListNode;
     }
 
     public function createWrapperNode(?Node $node, string $before = '', string $after = ''): WrapperNode

--- a/lib/NodeFactory/NodeFactory.php
+++ b/lib/NodeFactory/NodeFactory.php
@@ -13,6 +13,7 @@ use Doctrine\RST\Nodes\ContentsNode;
 use Doctrine\RST\Nodes\DefinitionListNode;
 use Doctrine\RST\Nodes\DocumentNode;
 use Doctrine\RST\Nodes\DummyNode;
+use Doctrine\RST\Nodes\FieldListNode;
 use Doctrine\RST\Nodes\FigureNode;
 use Doctrine\RST\Nodes\ImageNode;
 use Doctrine\RST\Nodes\ListNode;
@@ -32,6 +33,7 @@ use Doctrine\RST\Nodes\TocNode;
 use Doctrine\RST\Nodes\WrapperNode;
 use Doctrine\RST\Parser;
 use Doctrine\RST\Parser\DefinitionList;
+use Doctrine\RST\Parser\FieldOption;
 use Doctrine\RST\Parser\LineChecker;
 use Doctrine\RST\Parser\ListItem;
 use Doctrine\RST\Parser\TableSeparatorLineConfig;
@@ -74,6 +76,9 @@ interface NodeFactory
     public function createSpanNode(Parser $parser, $span): SpanNode;
 
     public function createDefinitionListNode(DefinitionList $definitionList): DefinitionListNode;
+
+    /** @param FieldOption[] $items */
+    public function createFieldListNode(array $items): FieldListNode;
 
     public function createWrapperNode(?Node $node, string $before = '', string $after = ''): WrapperNode;
 

--- a/lib/Nodes/FieldListNode.php
+++ b/lib/Nodes/FieldListNode.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\RST\Nodes;
+
+use Doctrine\RST\Parser\FieldOption;
+
+class FieldListNode extends Node
+{
+    /** @var FieldOption[] */
+    private $items;
+
+    /** @param FieldOption[] $items */
+    public function __construct(array $items)
+    {
+        parent::__construct();
+
+        $this->items = $items;
+    }
+
+    /** @return FieldOption[] */
+    public function getItems(): array
+    {
+        return $this->items;
+    }
+}

--- a/lib/Nodes/NodeTypes.php
+++ b/lib/Nodes/NodeTypes.php
@@ -19,6 +19,7 @@ final class NodeTypes
     public const LIST            = 'list';
     public const TABLE           = 'table';
     public const SPAN            = 'span';
+    public const FIELD_LIST      = 'field_list';
     public const DEFINITION_LIST = 'definition_list';
     public const WRAPPER         = 'wrapper';
     public const FIGURE          = 'figure';
@@ -46,6 +47,7 @@ final class NodeTypes
         self::LIST,
         self::TABLE,
         self::SPAN,
+        self::FIELD_LIST,
         self::DEFINITION_LIST,
         self::WRAPPER,
         self::FIGURE,

--- a/lib/Parser/LineChecker.php
+++ b/lib/Parser/LineChecker.php
@@ -109,7 +109,7 @@ class LineChecker
      */
     public function isBlockLine(string $line, int $minIndent = 1): bool
     {
-        return (trim($line) === '' || $this->isIndented($line, $minIndent)) && ! $this->isComment($line);
+        return ($this->isEmpty($line) || $this->isIndented($line, $minIndent)) && ! $this->isComment($line);
     }
 
     public function isComment(string $line): bool
@@ -150,7 +150,7 @@ class LineChecker
      */
     public function isDefinitionListEnded(string $line, string $nextLine): bool
     {
-        if (trim($line) === '') {
+        if ($this->isEmpty($line)) {
             return false;
         }
 
@@ -159,5 +159,22 @@ class LineChecker
         }
 
         return ! $this->isIndented($nextLine);
+    }
+
+    /**
+     * Checks if the current line can be considered part of the field list.
+     *
+     * Either the current line is indented or a new field list definition
+     *
+     * @see https://docutils.sourceforge.io/docs/ref/rst/restructuredtext.html#field-lists
+     */
+    public function isFieldListEnded(string $line): bool
+    {
+        return ! ($this->isEmpty($line) || $this->isIndented($line) || $this->isFieldOption($line));
+    }
+
+    public function isEmpty(string $line): bool
+    {
+        return trim($line) === '';
     }
 }

--- a/lib/Parser/State.php
+++ b/lib/Parser/State.php
@@ -36,4 +36,5 @@ final class State
     public const TABLE           = 'table';
     public const COMMENT         = 'comment';
     public const DEFINITION_LIST = 'definition_list';
+    public const FIELD_LIST      = 'field_list';
 }

--- a/lib/Templates/default/html/field-list.html.twig
+++ b/lib/Templates/default/html/field-list.html.twig
@@ -1,0 +1,6 @@
+<dl{% if listNode.classes %} class="{{ listNode.classesString }}"{% endif %}>
+    {% for item in listNode.items -%}
+        <dt>{{ item.name }}</dt>
+        <dd>{{ item.nodesAsString|raw }}</dd>
+    {%- endfor %}
+</dl>

--- a/lib/Toc/ToctreeBuilder.php
+++ b/lib/Toc/ToctreeBuilder.php
@@ -67,7 +67,7 @@ final class ToctreeBuilder
             }
         }
 
-        if ((bool) ($options['reversed'] ?? false)) {
+        if (isset($options['reversed'])) {
             $toctreeFiles = array_reverse($toctreeFiles);
         }
 

--- a/tests/Functional/tests/render/list-field/list-field.html
+++ b/tests/Functional/tests/render/list-field/list-field.html
@@ -1,0 +1,15 @@
+<div class="section" id="field-list">
+    <h1>Field List</h1>
+    <dl>
+        <dt>what</dt>
+        <dd>Field lists map field names to field bodies, like database records. They are often part of an extension
+            syntax.
+        </dd>
+        <dt>how</dt>
+        <dd>
+            <p class="first">The field marker is a colon, the field name, and a colon.</p>
+            <p class="last">The field body may contain one or more body elements, indented relative to the field
+                marker.</p>
+        </dd>
+    </dl>
+</div>

--- a/tests/Functional/tests/render/list-field/list-field.rst
+++ b/tests/Functional/tests/render/list-field/list-field.rst
@@ -1,0 +1,13 @@
+==========
+Field List
+==========
+
+:what:  Field lists map field names to field bodies, like
+        database records.  They are often part of an extension
+        syntax.
+
+:how:   The field marker is a colon, the field name, and a
+        colon.
+
+        The field body may contain one or more body elements,
+        indented relative to the field marker.

--- a/tests/Parser/LineCheckerTest.php
+++ b/tests/Parser/LineCheckerTest.php
@@ -107,4 +107,14 @@ class LineCheckerTest extends TestCase
         self::assertTrue($this->lineChecker->isFieldOption(':Date: published: 2001-08-16'));
         self::assertFalse($this->lineChecker->isFieldOption('Date: 2001-08-16'));
     }
+
+    public function testIsFieldListEnded(): void
+    {
+        self::assertFalse($this->lineChecker->isFieldListEnded(':what:'), 'Field definition continues field list');
+        self::assertFalse($this->lineChecker->isFieldListEnded(':what: Is this?'), 'Field definition with text continues field list');
+        self::assertFalse($this->lineChecker->isFieldListEnded('    And that?'), 'Indentation continues field list');
+        self::assertFalse($this->lineChecker->isFieldListEnded(''), 'Empty line continues field list');
+        self::assertFalse($this->lineChecker->isFieldListEnded('    '), 'Empty line (trimmed) continues field list');
+        self::assertTrue($this->lineChecker->isFieldListEnded('Just another unindented line'), 'Field list must end on unindented line');
+    }
 }

--- a/tests/Parser/LineDataParserTest.php
+++ b/tests/Parser/LineDataParserTest.php
@@ -11,6 +11,8 @@ use Doctrine\RST\Parser\Link;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
+use function explode;
+
 class LineDataParserTest extends TestCase
 {
     /** @var Parser */
@@ -71,12 +73,32 @@ class LineDataParserTest extends TestCase
     public function getTestFieldOptions(): array
     {
         return [
-            [':glob:', 'glob', true],
+            [':glob:', 'glob', ''],
             [':alt: Some text', 'alt', 'Some text'],
             [':date:published: 2022-09-20', 'date:published', '2022-09-20'],
             [':date\: published: 2022-09-20', 'date: published', '2022-09-20'],
             [':date: published: 2022-09-20', 'date', 'published: 2022-09-20'],
         ];
+    }
+
+    public function testParseFieldList(): void
+    {
+        $data         = <<<'EOD'
+:what:  Field lists map field names to field bodies, like
+        database records.  They are often part of an extension
+        syntax.
+
+:how:   The field marker is a colon, the field name, and a
+        colon.
+
+        The field body may contain one or more body elements,
+        indented relative to the field marker.
+EOD;
+        $lines        = explode("\n", $data);
+        $fieldOptions = $this->lineDataParser->parseFieldList($lines);
+        self::assertCount(2, $fieldOptions);
+        self::assertEquals('what', $fieldOptions[0]->getName());
+        self::assertEquals('how', $fieldOptions[1]->getName());
     }
 
     protected function setUp(): void

--- a/tests/Parser/ParserTest.php
+++ b/tests/Parser/ParserTest.php
@@ -314,7 +314,7 @@ class ParserTest extends TestCase
         self::assertTrue(isset($options['maxdepth']));
         self::assertTrue(isset($options['titlesonly']));
         self::assertTrue(isset($options['glob']));
-        self::assertTrue($options['titlesonly']);
+        self::assertEquals('', $options['titlesonly']);
         self::assertSame('123', $options['maxdepth']);
     }
 

--- a/tests/Renderer/FieldListNodeRendererTest.php
+++ b/tests/Renderer/FieldListNodeRendererTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\RST\Renderer;
+
+use Doctrine\RST\Configuration;
+use Doctrine\RST\Environment;
+use Doctrine\RST\HTML\Renderers\FieldListNodeRenderer;
+use Doctrine\RST\Nodes\FieldListNode;
+use Doctrine\RST\Parser\FieldOption;
+use PHPUnit\Framework\TestCase;
+
+final class FieldListNodeRendererTest extends TestCase
+{
+    private FieldListNode $listNode;
+    private FieldListNodeRenderer $fieldListNodeRenderer;
+
+    protected function setUp(): void
+    {
+        $environment                 = new Environment(new Configuration());
+        $this->listNode              = new FieldListNode([
+            new FieldOption('what', 0, 'that'),
+            new FieldOption('how', 0, 'like this'),
+        ]);
+        $this->fieldListNodeRenderer = new FieldListNodeRenderer($this->listNode, $environment->getTemplateRenderer());
+    }
+
+    public function testFieldListRenders(): void
+    {
+         self::assertStringContainsString('<dt>what</dt>', $this->fieldListNodeRenderer->render());
+    }
+}


### PR DESCRIPTION
Field lists can be used standalone: https://docutils.sourceforge.io/docs/user/rst/quickref.html#field-lists or in the content area of a directive. They are not the same as the field options which belong directly to the directive.