### PR TITLE
Address deprecation of utf8_{de,en}code()

### DIFF
--- a/lib/Nodes/Table/TableColumn.php
+++ b/lib/Nodes/Table/TableColumn.php
@@ -9,7 +9,6 @@ use LogicException;
 
 use function strlen;
 use function trim;
-use function utf8_encode;
 
 final class TableColumn
 {
@@ -23,7 +22,7 @@ final class TableColumn
 
     public function __construct(string $content, int $colSpan)
     {
-        $this->content = utf8_encode(trim($content));
+        $this->content = trim($content);
         $this->colSpan = $colSpan;
     }
 

--- a/lib/Nodes/TableNode.php
+++ b/lib/Nodes/TableNode.php
@@ -21,6 +21,7 @@ use function explode;
 use function implode;
 use function ksort;
 use function max;
+use function mb_substr;
 use function preg_match;
 use function sprintf;
 use function str_repeat;
@@ -28,7 +29,6 @@ use function strlen;
 use function strpos;
 use function substr;
 use function trim;
-use function utf8_decode;
 
 class TableNode extends Node
 {
@@ -133,7 +133,7 @@ class TableNode extends Node
             throw new LogicException('Cannot push data after TableNode is compiled');
         }
 
-        $this->rawDataLines[$this->currentLineNumber] = utf8_decode($line);
+        $this->rawDataLines[$this->currentLineNumber] = $line;
         $this->currentLineNumber++;
     }
 
@@ -360,7 +360,7 @@ class TableNode extends Node
                 }
 
                 if ($currentColumnStart !== null) {
-                    $gapText = substr($line, $previousColumnEnd, $start - $previousColumnEnd);
+                    $gapText = mb_substr($line, $previousColumnEnd, $start - $previousColumnEnd);
                     if (strpos($gapText, '|') === false && strpos($gapText, '+') === false) {
                         // text continued through the "gap". This is a colspan
                         // "+" is an odd character - it's usually "|", but "+" can
@@ -394,7 +394,7 @@ class TableNode extends Node
                 }
 
                 $row->addColumn(
-                    substr($line, $currentColumnStart, $previousColumnEnd - $currentColumnStart),
+                    mb_substr($line, $currentColumnStart, $previousColumnEnd - $currentColumnStart),
                     $currentSpan
                 );
             }


### PR DESCRIPTION
These functions are deprecated as of PHP 8.2, because they don't force the user to explicitly state both the source and target encoding. Anyway, I think this was just a hack to make `substr()` work with multi-byte characters. Instead of using a hack, let us use `mb_substr()`.

Note that I did not switch the entire library to `mb_*()` functions because it broke some tests, but it should probably be done at some point.

See https://wiki.php.net/rfc/remove_utf8_decode_and_utf8_encode