### PR TITLE
Parse admonition titles using the SpanParser

### DIFF
--- a/lib/Directives/Admonition.php
+++ b/lib/Directives/Admonition.php
@@ -43,11 +43,16 @@ class Admonition extends SubDirective
             throw new RuntimeException('Content expected, none found.');
         }
 
+        $text = $this->text;
+        if ($data !== '') {
+            $text = $parser->createSpanNode($data)->render();
+        }
+
         $wrapperDiv = $parser->renderTemplate(
             $this->template,
             [
                 'name' => $this->name,
-                'text' => $data !== '' ? $data : $this->text,
+                'text' => $text,
                 'class' => $options['class'] ?? null,
             ]
         );

--- a/lib/Templates/default/html/directives/admonition.html.twig
+++ b/lib/Templates/default/html/directives/admonition.html.twig
@@ -1,7 +1,7 @@
 <div class="alert {% include "directives/admonition-class.html.twig" %} border {{ class }}">
     <table width="100%">
         <tr>
-            <td width="10" class="align-top" title="{{ text }}">{% include "directives/admonition-icon.html.twig" %}</td>
+            <td width="10" class="align-top" title="{{ text|striptags }}">{% include "directives/admonition-icon.html.twig" %}</td>
             <td>
                 |||
             </td>

--- a/tests/Functional/tests/render/admonitions/admonitions.html
+++ b/tests/Functional/tests/render/admonitions/admonitions.html
@@ -1,7 +1,7 @@
 <div class="alert admonition-admonition bg-light text-dark border ">
     <table width="100%">
         <tr>
-            <td width="10" class="align-top" title="Custom title"><i class="far fa-comment"></i></td>
+            <td width="10" class="align-top" title="Custom title with markup"><i class="far fa-comment"></i></td>
             <td>
                 <p>Lorem Ipsum Dolor</p>
             </td>

--- a/tests/Functional/tests/render/admonitions/admonitions.rst
+++ b/tests/Functional/tests/render/admonitions/admonitions.rst
@@ -1,4 +1,4 @@
-.. admonition:: Custom title
+.. admonition:: Custom title with *markup*
     Lorem Ipsum Dolor
 
 .. attention::


### PR DESCRIPTION
Although I cannot find this in the markup specification, I have confirmed this behavior on Sphinx.

In the Symfony docs, we rely on the RST Parser allowing inline markup in the admonition title (see the failing test case in https://github.com/symfony-tools/docs-builder/pull/148). The admonition directives are introduced in 0.6.

Good news: this is the only "bug" found when updating the docs-builder to 0.6. As 0.5 doesn't support PHP 8.2 IIRC, I think it's good to work towards a stable 0.6 release. Let me know if there is anything else I can help with :)