### PR TITLE
Add support for fig* options in FigureNode

### DIFF
--- a/lib/HTML/Directives/Figure.php
+++ b/lib/HTML/Directives/Figure.php
@@ -9,7 +9,9 @@ use Doctrine\RST\Nodes\Node;
 use Doctrine\RST\Parser;
 use Exception;
 
+use function explode;
 use function sprintf;
+use function strpos;
 
 /**
  * Renders an image, example :
@@ -43,11 +45,30 @@ final class Figure extends SubDirective
             throw new Exception(sprintf('Could not get relative url for %s', $data));
         }
 
-        $nodeFactory = $parser->getNodeFactory();
+        $figureOptions = [];
+        foreach ($options as $name => $value) {
+            if (strpos($name, 'fig') !== 0) {
+                continue;
+            }
 
-        return $parser->getNodeFactory()->createFigureNode(
+            $figureOptions[$name] = $value;
+            unset($options[$name]);
+        }
+
+        $nodeFactory = $parser->getNodeFactory();
+        $figureNode  = $nodeFactory->createFigureNode(
             $nodeFactory->createImageNode($url, $options),
             $document
         );
+
+        if (isset($figureOptions['figclass'])) {
+            $figureNode->setClasses(explode(' ', $figureOptions['figclass']));
+        }
+
+        if (isset($figureOptions['figwidth'])) {
+            $figureNode->setWidth($figureOptions['figwidth']);
+        }
+
+        return $figureNode;
     }
 }

--- a/lib/Nodes/FigureNode.php
+++ b/lib/Nodes/FigureNode.php
@@ -10,6 +10,8 @@ final class FigureNode extends Node
 
     private ?Node $document = null;
 
+    private ?string $width = null;
+
     public function __construct(ImageNode $image, ?Node $document = null)
     {
         parent::__construct();
@@ -26,5 +28,15 @@ final class FigureNode extends Node
     public function getDocument(): ?Node
     {
         return $this->document;
+    }
+
+    public function setWidth(string $width): void
+    {
+        $this->width = $width;
+    }
+
+    public function getWidth(): ?string
+    {
+        return $this->width;
     }
 }

--- a/lib/Templates/default/html/figure.html.twig
+++ b/lib/Templates/default/html/figure.html.twig
@@ -1,5 +1,8 @@
 {% apply spaceless %}
-<figure>
+<figure
+    {%- if figureNode.width is not empty %} width="{{ figureNode.width }}"{% endif -%}
+    {%- if figureNode.classes is not empty %} class="{{ figureNode.classesString }}"{% endif -%}
+>
     {{ figureNode.image.render()|raw }}
 
     {% if figureNode.document %}

--- a/tests/Functional/tests/render/figure/figure.html
+++ b/tests/Functional/tests/render/figure/figure.html
@@ -4,3 +4,10 @@
         <p>This is a foo!</p>
     </figcaption>
 </figure>
+
+<figure width="200" class="something">
+    <img src="foo.jpg" width="100" />
+    <figcaption>
+        <p>This is a foo!</p>
+    </figcaption>
+</figure>

--- a/tests/Functional/tests/render/figure/figure.rst
+++ b/tests/Functional/tests/render/figure/figure.rst
@@ -4,3 +4,10 @@
       more than one line
 
     This is a foo!
+
+.. figure:: foo.jpg
+    :width: 100
+    :figwidth: 200
+    :figclass: something
+
+    This is a foo!


### PR DESCRIPTION
I was too fast, there is one other "bug" in 0.6: reStructuredText supports some options prefixed with `fig` on a figure node. These options apply to the wrapping `<figure>` element, rather than the `<img>`.