### PR TITLE
Do not register references as link targets

### DIFF
--- a/lib/TextRoles/LinkTextRole.php
+++ b/lib/TextRoles/LinkTextRole.php
@@ -6,7 +6,6 @@ namespace Doctrine\RST\TextRoles;
 
 use Doctrine\RST\Environment;
 use Doctrine\RST\InvalidLink;
-use Doctrine\RST\Meta\LinkTarget;
 use Doctrine\RST\Span\SpanProcessor;
 use Doctrine\RST\Span\SpanToken;
 
@@ -135,18 +134,12 @@ abstract class LinkTextRole extends SpecialTextRole
         if (preg_match('/^(.+)[ \n]<(.+)>$/mUsi', $link, $m) > 0) {
             $link = $m[1];
             $url  = $m[2];
-            if (! $anonymous) {
-                $this->environment->setLinkTarget(new LinkTarget($link, $url));
-            }
         }
 
         // extract the url if the link was in this format: `<https://www.google.com>`_
         if (preg_match('/^<(.+)>$/mUsi', $link, $m) > 0) {
             $link = $m[1];
             $url  = $m[1];
-            if (! $anonymous) {
-                $this->environment->setLinkTarget(new LinkTarget($link, $url));
-            }
         }
 
         $id = $this->spanProcessor->generateId();

--- a/tests/Builder/BuilderTest.php
+++ b/tests/Builder/BuilderTest.php
@@ -373,7 +373,7 @@ class BuilderTest extends BaseBuilderTest
         );
 
         self::assertStringContainsString(
-            '<p>see <a href="http://absolute/">test</a></p>',
+            '<p>see <a href="magic-link.html#test">test</a></p>',
             $contents
         );
 

--- a/tests/BuilderReferences/expected/index.html
+++ b/tests/BuilderReferences/expected/index.html
@@ -11,6 +11,8 @@
             <p>Test referencing a <a href="index.html#sub-section">Sub section</a> and Some Sub Section (invalid)</p>
             <div class="section" id="sub-section">
                 <h2>Sub section</h2>
+                <p>Test <a href="https://doctrine-project.org">reference to external target</a> and <a href="reference to external target">external reference with label</a>.</p>
+                <p>Test <a href="https://github.com/doctrine/rst-parser">inline external reference</a>.</p>
             </div>
         </div>
     </body>

--- a/tests/BuilderReferences/input/index.rst
+++ b/tests/BuilderReferences/input/index.rst
@@ -9,3 +9,10 @@ Test referencing a `Sub section`_ and `Some Sub Section`_ (invalid)
 
 Sub section
 -----------
+
+Test `reference to external target`_ and `external reference with label
+<reference to external target>`_.
+
+Test `inline external reference <https://github.com/doctrine/rst-parser>`_.
+
+.. _`reference to external target`: https://doctrine-project.org

--- a/tests/BuilderReferences/input/reference.rst
+++ b/tests/BuilderReferences/input/reference.rst
@@ -4,3 +4,10 @@ Reference
 =========
 
 Test
+
+.. These external targets are duplicated in index.rst and should not produce a warning
+
+Test `reference to external target`_ and `external reference with label
+<reference to external target>`_.
+
+Test `inline external reference <https://github.com/doctrine/rst-parser>`_.

--- a/tests/SpanProcessorTest.php
+++ b/tests/SpanProcessorTest.php
@@ -5,8 +5,6 @@ declare(strict_types=1);
 namespace Doctrine\Tests\RST;
 
 use Doctrine\RST\Environment;
-use Doctrine\RST\HTML\TextRoles\LinkTextRole;
-use Doctrine\RST\Meta\LinkTarget;
 use Doctrine\RST\Span\SpanProcessor;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -19,23 +17,6 @@ class SpanProcessorTest extends TestCase
     protected function setUp(): void
     {
         $this->environment = $this->createMock(Environment::class);
-    }
-
-    public function testProcessingLinkSpanSetsLinkTarget(): void
-    {
-        $this->environment->method('getSpecialTextRoles')->willReturn([new LinkTextRole()]);
-        $this->environment->expects(self::exactly(1))
-            ->method('setLinkTarget')
-            ->with(new LinkTarget('example', 'http://example.org/'));
-        $spanProcessor = new SpanProcessor($this->environment, '`example <http://example.org/>`_');
-        $spanProcessor->process();
-    }
-
-    public function testProcessingAnonymousLinkSpanDoesNotSetLinkTarget(): void
-    {
-        $this->environment->expects(self::never())->method('setLinkTarget');
-        $spanProcessor = new SpanProcessor($this->environment, '`example <http://example.org/>`__');
-        $spanProcessor->process();
     }
 
     public function testGenerateIdIsUnique(): void


### PR DESCRIPTION
The `` `...`_ `` syntax is a reference. The class was registering these as link targets in the meta. This resulted in many "duplicate link target" warnings when rendering the Symfony docs on 0.6 (as link targets cannot be duplicated across a project, but references can).