### PR TITLE
Allow to install Symfony 7 dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,10 +26,10 @@
     "require": {
         "php": "^7.2 || ^8.0",
         "doctrine/event-manager": "^1.0 || ^2.0",
-        "symfony/filesystem": "^4.1 || ^5.0 || ^6.0",
-        "symfony/finder": "^4.1 || ^5.0 || ^6.0",
+        "symfony/filesystem": "^4.1 || ^5.0 || ^6.0 || ^7.0",
+        "symfony/finder": "^4.1 || ^5.0 || ^6.0 || ^7.0",
         "symfony/polyfill-mbstring": "^1.0",
-        "symfony/string": "^5.3 || ^6.0",
+        "symfony/string": "^5.3 || ^6.0 || ^7.0",
         "symfony/translation-contracts": "^1.1 || ^2.0 || ^3.0",
         "twig/twig": "^2.9 || ^3.3"
     },
@@ -41,8 +41,8 @@
         "phpstan/phpstan-phpunit": "^1.2",
         "phpstan/phpstan-strict-rules": "^1.4",
         "phpunit/phpunit": "^7.5 || ^8.0 || ^9.0",
-        "symfony/css-selector": "4.4 || ^5.2 || ^6.0",
-        "symfony/dom-crawler": "4.4 || ^5.2 || ^6.0"
+        "symfony/css-selector": "4.4 || ^5.2 || ^6.0 || ^7.0",
+        "symfony/dom-crawler": "4.4 || ^5.2 || ^6.0 || ^7.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
I'm updating some complex apps to Symfony 7.0 and this change is needed because we use this package via `symfony-tools/docs-builder`.  Thanks!