### PR TITLE
Normalize paths to run on windows

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -47,7 +47,10 @@
     "autoload": {
         "psr-4": {
             "Doctrine\\RST\\": "lib/"
-        }
+        },
+        "files": [
+            "polyfill.php"
+        ]
     },
     "autoload-dev": {
         "psr-4": {

--- a/lib/Builder.php
+++ b/lib/Builder.php
@@ -17,6 +17,7 @@ use Doctrine\RST\Meta\CachedMetasLoader;
 use Doctrine\RST\Meta\Metas;
 use InvalidArgumentException;
 use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\Filesystem\Path;
 use Symfony\Component\Finder\Finder;
 
 use function file_exists;
@@ -132,6 +133,8 @@ final class Builder
         string $directory,
         string $targetDirectory = 'output'
     ): void {
+        $directory       = Path::normalize($directory);
+        $targetDirectory = Path::normalize($targetDirectory);
         // Creating output directory if doesn't exists
         if (! is_dir($targetDirectory)) {
             $this->filesystem->mkdir($targetDirectory, 0755);

--- a/lib/Builder/Scanner.php
+++ b/lib/Builder/Scanner.php
@@ -6,6 +6,7 @@ namespace Doctrine\RST\Builder;
 
 use Doctrine\RST\Meta\Metas;
 use InvalidArgumentException;
+use Symfony\Component\Filesystem\Path;
 use Symfony\Component\Finder\Finder;
 use Symfony\Component\Finder\SplFileInfo;
 
@@ -54,7 +55,7 @@ final class Scanner
         // completely populate the splFileInfos property
         $this->fileInfos = [];
         foreach ($this->finder as $fileInfo) {
-            $relativeFilename = $fileInfo->getRelativePathname();
+            $relativeFilename = Path::normalize($fileInfo->getRelativePathname());
             // strip off the extension
             $documentPath = substr($relativeFilename, 0, -(strlen($this->fileExtension) + 1));
 
@@ -142,6 +143,6 @@ final class Scanner
      */
     private function getFilenameFromFile(SplFileInfo $file): string
     {
-        return substr($file->getRelativePathname(), 0, -(strlen($this->fileExtension) + 1));
+        return substr(Path::normalize($file->getRelativePathname()), 0, -(strlen($this->fileExtension) + 1));
     }
 }

--- a/lib/Configuration.php
+++ b/lib/Configuration.php
@@ -20,8 +20,10 @@ use Doctrine\RST\Templates\TemplateRenderer;
 use Doctrine\RST\Templates\TwigAdapter;
 use Doctrine\RST\Templates\TwigTemplateRenderer;
 use RuntimeException;
+use Symfony\Component\Filesystem\Path;
 use Twig\Environment as TwigEnvironment;
 
+use function array_map;
 use function sprintf;
 use function sys_get_temp_dir;
 
@@ -93,7 +95,7 @@ class Configuration
 
     public function __construct()
     {
-        $this->cacheDir = sys_get_temp_dir() . '/doctrine-rst-parser';
+        $this->cacheDir = Path::normalize(sys_get_temp_dir()) . '/doctrine-rst-parser';
 
         $this->eventManager = new EventManager();
 
@@ -113,7 +115,7 @@ class Configuration
 
     public function setCacheDir(string $cacheDir): void
     {
-        $this->cacheDir = $cacheDir;
+        $this->cacheDir = Path::normalize($cacheDir);
     }
 
     public function getTemplateRenderer(): TemplateRenderer
@@ -141,7 +143,7 @@ class Configuration
     /** @param string[] $customTemplateDirs */
     public function setCustomTemplateDirs(array $customTemplateDirs): void
     {
-        $this->customTemplateDirs = $customTemplateDirs;
+        $this->customTemplateDirs = array_map([Path::class, 'normalize'], $customTemplateDirs);
     }
 
     public function addCustomTemplateDir(string $customTemplateDir): void

--- a/lib/Environment.php
+++ b/lib/Environment.php
@@ -11,6 +11,7 @@ use Doctrine\RST\References\Reference;
 use Doctrine\RST\References\ResolvedReference;
 use Doctrine\RST\Templates\TemplateRenderer;
 use InvalidArgumentException;
+use Symfony\Component\Filesystem\Path;
 use Symfony\Component\String\Slugger\AsciiSlugger;
 
 use function array_shift;
@@ -372,7 +373,7 @@ class Environment
 
     public function setCurrentFileName(string $filename): void
     {
-        $this->currentFileName = $filename;
+        $this->currentFileName = Path::normalize($filename);
     }
 
     /**
@@ -388,7 +389,7 @@ class Environment
 
     public function setCurrentDirectory(string $directory): void
     {
-        $this->currentDirectory = $directory;
+        $this->currentDirectory = Path::normalize($directory);
     }
 
     public function getCurrentDirectory(): string
@@ -403,7 +404,7 @@ class Environment
 
     public function setTargetDirectory(string $directory): void
     {
-        $this->targetDirectory = $directory;
+        $this->targetDirectory = Path::normalize($directory);
     }
 
     public function getTargetDirectory(): string

--- a/lib/FileIncluder.php
+++ b/lib/FileIncluder.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\RST;
 
 use RuntimeException;
+use Symfony\Component\Filesystem\Path;
 
 use function explode;
 use function file_exists;
@@ -26,6 +27,7 @@ final class FileIncluder
     /** @var string */
     private $includeRoot;
 
+    /** @param string $includeRoot Many roots can be provided by separating them with | */
     public function __construct(
         Environment $environment,
         bool $includeAllowed,
@@ -83,7 +85,9 @@ final class FileIncluder
             return false;
         }
 
-        foreach (explode(':', $this->includeRoot) as $root) {
+        $real = Path::normalize($real);
+
+        foreach (explode('|', $this->includeRoot) as $root) {
             if (strpos($real, $root) === 0) {
                 return true;
             }

--- a/lib/Nodes/TocNode.php
+++ b/lib/Nodes/TocNode.php
@@ -5,6 +5,9 @@ declare(strict_types=1);
 namespace Doctrine\RST\Nodes;
 
 use Doctrine\RST\Environment;
+use Symfony\Component\Filesystem\Path;
+
+use function array_map;
 
 class TocNode extends Node
 {
@@ -27,7 +30,7 @@ class TocNode extends Node
     {
         parent::__construct();
 
-        $this->files       = $files;
+        $this->files       = array_map([Path::class, 'normalize'], $files);
         $this->environment = $environment;
         $this->options     = $options;
     }

--- a/lib/Templates/TwigEnvironmentFactory.php
+++ b/lib/Templates/TwigEnvironmentFactory.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\RST\Templates;
 
 use Doctrine\RST\Configuration;
+use Symfony\Component\Filesystem\Path;
 use Twig\Environment as TwigEnvironment;
 use Twig\Loader\FilesystemLoader;
 
@@ -32,7 +33,7 @@ final class TwigEnvironmentFactory
 
         $templateDirectories = $configuration->getCustomTemplateDirs();
         // add the fallback directory
-        $templateDirectories[] = __DIR__;
+        $templateDirectories[] = Path::normalize(__DIR__);
 
         foreach ($templateDirectories as $templateDir) {
             $themePath = $templateDir . '/' . $configuration->getTheme() . '/' . $fileExtension;

--- a/lib/Toc/GlobSearcher.php
+++ b/lib/Toc/GlobSearcher.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Doctrine\RST\Toc;
 
 use Doctrine\RST\Environment;
+use Symfony\Component\Filesystem\Path;
 use Symfony\Component\Finder\Finder;
 
 use function array_merge;
@@ -27,7 +28,7 @@ class GlobSearcher
      */
     public function globSearch(Environment $environment, string $globPattern): array
     {
-        $currentFilePath = (string) realpath(rtrim($environment->absoluteRelativePath(''), '/'));
+        $currentFilePath = Path::normalize((string) realpath(rtrim($environment->absoluteRelativePath(''), '/')));
 
         $rootDocPath = rtrim(str_replace($environment->getDirName(), '', $currentFilePath), '/');
 
@@ -51,7 +52,7 @@ class GlobSearcher
         foreach ($finder as $file) {
             if ($file->isDir()) {
                 // remove the root directory so it is a relative path from the root
-                $relativePath = str_replace($rootDocPath, '', (string) $file->getRealPath());
+                $relativePath = str_replace($rootDocPath, '', Path::normalize((string) $file->getRealPath()));
 
                 // recursively search in this directory
                 $dirFiles = $this->globSearch($environment, $relativePath . '/*');
@@ -60,7 +61,7 @@ class GlobSearcher
             } else {
                 // Trim the root path and the .rst extension. This is what the
                 // RST parser requires to add a dependency.
-                $file = str_replace([$rootDocPath, '.rst'], '', (string) $file->getRealPath());
+                $file = str_replace([$rootDocPath, '.rst'], '', Path::normalize((string) $file->getRealPath()));
 
                 $allFiles[] = $file;
             }

--- a/polyfill.php
+++ b/polyfill.php
@@ -1,0 +1,14 @@
+<?php
+
+if (!class_exists(Symfony\Component\Filesystem\Path::class)) {
+    class Symfony_Component_Filesystem_Path_Polyfill {
+        public static function normalize($path): string
+        {
+            return str_replace('\\', '/', $path);
+        }
+    }
+    class_alias(
+        Symfony_Component_Filesystem_Path_Polyfill::class,
+        Symfony\Component\Filesystem\Path::class
+    );
+}

--- a/tests/BaseBuilderTest.php
+++ b/tests/BaseBuilderTest.php
@@ -7,6 +7,7 @@ namespace Doctrine\Tests\RST;
 use Doctrine\RST\Builder;
 use Exception;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Filesystem\Path;
 
 use function file_get_contents;
 use function shell_exec;
@@ -34,12 +35,12 @@ abstract class BaseBuilderTest extends TestCase
 
     protected function sourceFile(string $file = ''): string
     {
-        return __DIR__ . '/' . $this->getFixturesDirectory() . '/input/' . $file;
+        return Path::normalize(__DIR__) . '/' . $this->getFixturesDirectory() . '/input/' . $file;
     }
 
     protected function targetFile(string $file = ''): string
     {
-        return __DIR__ . '/' . $this->getFixturesDirectory() . '/output/' . $file;
+        return Path::normalize(__DIR__) . '/' . $this->getFixturesDirectory() . '/output/' . $file;
     }
 
     /** @throws Exception */

--- a/tests/FileIncluderTest.php
+++ b/tests/FileIncluderTest.php
@@ -9,6 +9,7 @@ use Doctrine\RST\FileIncluder;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
+use Symfony\Component\Filesystem\Path;
 
 use function trim;
 
@@ -22,9 +23,9 @@ class FileIncluderTest extends TestCase
         $this->environment->expects(self::once())
             ->method('absoluteRelativePath')
             ->with('include.rst')
-            ->willReturn(__DIR__ . '/Parser/files/include.rst');
+            ->willReturn(Path::normalize(__DIR__) . '/Parser/files/include.rst');
 
-        $fileIncluder = new FileIncluder($this->environment, true, __DIR__ . '/Parser/files');
+        $fileIncluder = new FileIncluder($this->environment, true, Path::normalize(__DIR__) . '/Parser/files');
 
         $contents = $fileIncluder->includeFiles('.. include:: include.rst');
 
@@ -36,7 +37,7 @@ class FileIncluderTest extends TestCase
         $this->environment->expects(self::once())
             ->method('absoluteRelativePath')
             ->with('include.rst')
-            ->willReturn(__DIR__ . '/Parser/files/include.rst');
+            ->willReturn(Path::normalize(__DIR__) . '/Parser/files/include.rst');
 
         $fileIncluder = new FileIncluder($this->environment, true, '');
 

--- a/tests/GlobSearcherTest.php
+++ b/tests/GlobSearcherTest.php
@@ -7,6 +7,7 @@ namespace Doctrine\Tests\RST;
 use Doctrine\RST\Environment;
 use Doctrine\RST\Toc\GlobSearcher;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\Filesystem\Path;
 
 use function sort;
 
@@ -17,7 +18,7 @@ class GlobSearcherTest extends TestCase
 
     public function testGlobSearch(): void
     {
-        $dir = __DIR__ . '/BuilderToctree/input';
+        $dir = Path::normalize(__DIR__) . '/BuilderToctree/input';
 
         $environment = $this->createMock(Environment::class);
 

--- a/tests/Parser/ParserTest.php
+++ b/tests/Parser/ParserTest.php
@@ -18,6 +18,7 @@ use Exception;
 use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 use RuntimeException;
+use Symfony\Component\Filesystem\Path;
 
 use function assert;
 use function count;
@@ -383,7 +384,7 @@ class ParserTest extends TestCase
 
     public function testIncludesPolicy(): void
     {
-        $directory   = __DIR__ . '/files/';
+        $directory   = Path::normalize(__DIR__) . '/files/';
         $parser      = new Parser();
         $environment = $parser->getEnvironment();
         $environment->setCurrentDirectory($directory);
@@ -397,7 +398,7 @@ class ParserTest extends TestCase
         self::assertStringContainsString('SUBDIRECTORY OK', $document);
         self::assertStringContainsString('EXTERNAL FILE INCLUDED!', $document);
 
-        // Disbaled policy:
+        // Disabled policy:
         $parser->setIncludePolicy(false);
         $nodes = $parser->parseFile($directory . 'inclusion-policy.rst')->getNodes();
         self::assertCount(1, $nodes);

--- a/tests/Templates/TwigEnvironmentFactoryTest.php
+++ b/tests/Templates/TwigEnvironmentFactoryTest.php
@@ -9,6 +9,7 @@ use Doctrine\RST\Templates\TwigEnvironmentFactory;
 use Exception;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\Filesystem\Path;
 use Twig\Environment;
 use Twig\Loader\FilesystemLoader;
 
@@ -29,7 +30,7 @@ class TwigEnvironmentFactoryTest extends TestCase
 
         // no theme, no custom dirs
         self::assertLoaderPaths(
-            [(string) realpath(__DIR__ . '/../../lib/Templates/default/html')],
+            [Path::normalize((string) realpath(__DIR__ . '/../../lib/Templates/default/html'))],
             TwigEnvironmentFactory::createTwigEnvironment($configuration)
         );
     }
@@ -61,7 +62,7 @@ class TwigEnvironmentFactoryTest extends TestCase
                 $dir1 . '/cool_theme/html',
                 $dir2 . '/cool_theme/html',
                 $dir1 . '/default/html',
-                (string) realpath(__DIR__ . '/../../lib/Templates/default/html'),
+                Path::normalize((string) realpath(__DIR__ . '/../../lib/Templates/default/html')),
             ],
             TwigEnvironmentFactory::createTwigEnvironment($configuration)
         );
@@ -80,7 +81,7 @@ class TwigEnvironmentFactoryTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->tmpPath    = sys_get_temp_dir() . '/_rst_twig_tests';
+        $this->tmpPath    = Path::normalize(sys_get_temp_dir()) . '/_rst_twig_tests';
         $this->filesystem = new Filesystem();
     }
 


### PR DESCRIPTION
On windows all paths returned by build-in functions or SplFile object methods contain \ as directory separator. This breaks many things, like calculating relative directory for file being parsed, to include other files.

This can be easily fixed by using `Symfony\Component\Filesystem\Path::normalize` on any path that may be used to compare against other strings.

Windows path starts with partition letter followed by colon, so there is potential BC break in `FileIncluder.php`, where colon was used as path separator for `$includeRoot` argument. This feature to pass multiple roots was undocumented and there were no tests for it, so I hope this change will not have much impact.
