### PR TITLE
Remove redundant 0.2 reference

### DIFF
--- a/.doctrine-project.json
+++ b/.doctrine-project.json
@@ -41,12 +41,6 @@
             "maintained": false
         },
         {
-            "name": "0.2",
-            "branchName": "0.2.x",
-            "slug": "0.2",
-            "maintained": false
-        },
-        {
             "name": "0.1",
             "branchName": "0.1.x",
             "slug": "0.1",


### PR DESCRIPTION
0.2 is two times in the doctrine-project config. One can be removed. I found this during my work on the Doctrine website where changes expects that values of the versions are supposed to be unique.