### PR TITLE
Group Doctrine workflow updates together

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "CI"
+    groups:
+      doctrine:
+        patterns:
+          - "doctrine/*"


### PR DESCRIPTION
We do very small releases, often touching only one workflow, which means it is unlikely to have several issues when attempting to bump several references to this repository.