### PR TITLE
Render backtick-quoted links whose text starts with an underscore

### DIFF
--- a/lib/Span/SpanProcessor.php
+++ b/lib/Span/SpanProcessor.php
@@ -168,8 +168,10 @@ final class SpanProcessor
             $link = $match[3] ? $match[3] : $match[5];
             assert(is_string($link));
 
-            // a link starting with _ is not a link - return original string
-            if (substr($link, 0, 1) === '_') {
+            // a plain-text word starting with _ (e.g. PHP's __CLASS__) is not
+            // a link - return original string. Backtick-quoted text is always
+            // an explicit link, whatever its first character.
+            if ($match[3] !== '' && substr($link, 0, 1) === '_') {
                 return $match[0];
             }
 

--- a/tests/LinkParserTest.php
+++ b/tests/LinkParserTest.php
@@ -39,6 +39,39 @@ EOF;
         self::assertSame('<p><a href="https://www.google.com">has_underscore</a></p>', trim($result));
     }
 
+    public function testLinkWithTextStartingWithUnderscore(): void
+    {
+        $rst = <<<'EOF'
+the `__invoke() PHP magic method`_
+
+.. _`__invoke() PHP magic method`: https://www.php.net/manual/en/language.oop5.magic.php#object.invoke
+EOF;
+
+        $result = $this->parser->parse($rst)->render();
+
+        self::assertSame('<p>the <a href="https://www.php.net/manual/en/language.oop5.magic.php#object.invoke">__invoke() PHP magic method</a></p>', trim($result));
+    }
+
+    public function testAnonymousLinkWithTextStartingWithUnderscore(): void
+    {
+        $rst = <<<'EOF'
+the `__toString() PHP magic method`__
+
+__ https://www.php.net/manual/en/language.oop5.magic.php#object.tostring
+EOF;
+
+        $result = $this->parser->parse($rst)->render();
+
+        self::assertSame('<p>the <a href="https://www.php.net/manual/en/language.oop5.magic.php#object.tostring">__toString() PHP magic method</a></p>', trim($result));
+    }
+
+    public function testPlainTextStartingWithUnderscoreIsNotALink(): void
+    {
+        $result = $this->parser->parse('text with __CLASS__ and __invoke_ is not a link')->render();
+
+        self::assertSame('<p>text with __CLASS__ and __invoke_ is not a link</p>', trim($result));
+    }
+
     public function testInvalidLinks(): void
     {
         $this->configuration->setIgnoreInvalidReferences(true);


### PR DESCRIPTION
#### Summary

Backtick-quoted hyperlink references whose text starts with an underscore, like:

```rst
the `__invoke() PHP magic method`_

.. _`__invoke() PHP magic method`: https://www.php.net/manual/en/language.oop5.magic.php#object.invoke
```

are left unrendered as raw RST, while docutils/Sphinx render them as links. Real-world case: the [Symfony Twig configuration docs](https://symfony.com/doc/current/reference/configuration/twig.html#autoescape-service-method) (reported in symfony-tools/docs-builder#189).

The guard was introduced in #79 to keep plain-text words like PHP's `__CLASS__` from being parsed as (anonymous) links. But it checks the first character of the link *text*, so it also rejects backtick-quoted references — where the markup makes the link intent explicit. This PR keeps the guard for plain-text words (`$match[3]`) and lifts it for backtick-quoted ones (`$match[5]`), for both named and anonymous references.

Covered by three new tests; the existing `__CLASS__` fixture (`tests/Functional/tests/render/anonymous`) still passes.
