### PR TITLE
Escape the text of unresolved links

### DIFF
--- a/lib/Renderers/SpanNodeRenderer.php
+++ b/lib/Renderers/SpanNodeRenderer.php
@@ -179,7 +179,9 @@ abstract class SpanNodeRenderer implements NodeRenderer, SpanRenderer
             if ($url === '') {
                 $this->environment->addInvalidLink(new InvalidLink($link));
 
-                return str_replace($spanToken->getId(), $link, $span);
+                // render the link text the same way a resolved link would,
+                // so that characters like < and > are properly escaped
+                return str_replace($spanToken->getId(), $this->renderSyntaxes($link), $span);
             }
         }
 

--- a/tests/LinkParserTest.php
+++ b/tests/LinkParserTest.php
@@ -39,6 +39,18 @@ EOF;
         self::assertSame('<p><a href="https://www.google.com">has_underscore</a></p>', trim($result));
     }
 
+    public function testInvalidLinkTextIsEscaped(): void
+    {
+        $this->configuration->setIgnoreInvalidReferences(true);
+        $this->configuration->abortOnError(false);
+
+        $rst = 'See the `related packages on Packagist.org<https://packagist.org/packages/scheb/2fa-bundle/dependents>`_.';
+
+        $result = $this->parser->parse($rst)->render();
+
+        self::assertSame('<p>See the related packages on Packagist.org&lt;https://packagist.org/packages/scheb/2fa-bundle/dependents&gt;.</p>', trim($result));
+    }
+
     public function testInvalidLinks(): void
     {
         $this->configuration->setIgnoreInvalidReferences(true);


### PR DESCRIPTION
#### Summary

When a hyperlink reference cannot be resolved, its text is injected back into the output as-is, without any HTML escaping. If that text contains `<` or `>`, the generated HTML is broken.

Real-world case (reported in symfony-tools/docs-builder#171): the scheb/2fa-bundle docs contained a reference with a missing space before the embedded URL:

```rst
`related packages on Packagist.org<https://packagist.org/packages/scheb/2fa-bundle/dependents>`_
```

Per the RST spec, the whole content (including `<https://...>`) is then the link *text*. The reference is unresolvable, and the raw `<https://...>` ends up in the HTML, which browsers mangle into invisible garbage.

The `link.html.twig` template outputs `{{ title|raw }}`, so escaping is the PHP side's responsibility: the resolved-link path already does it by passing the text through `renderSyntaxes()` (which starts with `escape()`). This PR applies the same treatment to the unresolved fallback, so the text now renders as visible, escaped plain text: consistent with how docutils/Sphinx degrade.

Note: the `:ref:`-style unresolved path (`renderReference()`) has a similar characteristic, but changing it could affect custom reference implementations that inject markup in titles, so it is deliberately left out of scope here.
