### PR TITLE
Run the end of life PHP jobs without Composer advisory blocking

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -29,6 +29,51 @@ jobs:
     name: "PHPUnit"
     uses: "doctrine/.github/.github/workflows/continuous-integration.yml@15.1.0"
     with:
-      php-versions: '["7.2", "7.3", "7.4", "8.0", "8.1", "8.2", "8.3", "8.4", "8.5"]'
+      php-versions: '["8.1", "8.2", "8.3", "8.4", "8.5"]'
     secrets:
       CODECOV_TOKEN: "${{ secrets.CODECOV_TOKEN }}"
+
+  # Every twig/twig release below 3.27 is flagged by a security advisory, and 3.27 requires
+  # PHP >= 8.1, so the PHP versions that are themselves end of life have nothing left to install
+  # while Composer blocks affected packages. The reusable workflow has no hook to run a command
+  # before the install, so they get their own job rather than turning the blocking off for
+  # everyone. See #293.
+  phpunit-eol-php:
+    name: "PHPUnit (end of life PHP)"
+    runs-on: "ubuntu-22.04"
+
+    strategy:
+      matrix:
+        php-version:
+          - "7.2"
+          - "7.3"
+          - "7.4"
+          - "8.0"
+        dependencies:
+          - "highest"
+        include:
+          - php-version: "7.2"
+            dependencies: "lowest"
+
+    steps:
+      - name: "Checkout"
+        uses: "actions/checkout@v6"
+
+      - name: "Install PHP"
+        uses: "shivammathur/setup-php@v2"
+        with:
+          php-version: "${{ matrix.php-version }}"
+          coverage: "none"
+          ini-file: development
+
+      - name: "Accept the advisory-affected Twig releases these PHP versions are left with"
+        run: "composer config audit.block-insecure false"
+
+      - name: "Install dependencies with Composer"
+        uses: "ramsey/composer-install@v4"
+        with:
+          dependency-versions: "${{ matrix.dependencies }}"
+          composer-options: "--prefer-dist"
+
+      - name: "Run PHPUnit"
+        run: "vendor/bin/phpunit"


### PR DESCRIPTION
Fixes #293

`composer update` fails on PHP 7.2, 7.3, 7.4 and 8.0, so those four CI jobs cannot run. Every Twig release below 3.27 is flagged by a security advisory, 3.27 requires PHP >= 8.1, and Composer blocks advisory-affected packages by default.

Those four versions now get their own job, which runs `composer config audit.block-insecure false` before installing. The reusable workflow keeps 8.1 and up untouched, and nothing is committed to `composer.json`, so a normal install of this repository is still protected.

They need a job of their own because the reusable workflow has no hook to run a command before the install, and `composer-options` cannot carry it: neither `--no-audit` nor `COMPOSER_AUDIT_BLOCK_INSECURE=0` lifts the block, only the config setting does. Verified on platform PHP 7.2.34 with Composer 2.9.5, where `twig/twig` then resolves to 3.11.3 for `highest` and 2.9.0 for `lowest`. The new job carries its own `lowest` run on 7.2.

Dropping 7.2 to 8.0 from the reusable workflow moves its `lowest` job to 8.1, and there `phpunit/phpunit` resolved to 8.5, whose mock generator cannot handle the union types this test suite uses (`ReflectionUnionType::getName()`). The `require-dev` constraint becomes `^7.5 || ^9.5` so that install picks 9.6 instead. Checked at lowest on platform 8.1.34, where the suite passes with PHPUnit 9.6.33, and on platform 7.2.34, which still resolves PHPUnit 7.5.0 with Twig 2.9.0 for the end of life job.

Adding an input to `doctrine/.github` and calling the reusable workflow twice would do the same thing without the extra job, happy to send that instead.

